### PR TITLE
feat(api): add ConsensusServiceAPI trait and refactor types

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,67 @@
+use alloy_signer::Signer;
+
+use crate::{
+    error::ConsensusError,
+    events::ConsensusEventBus,
+    protos::consensus::v1::{Proposal, Vote},
+    scope::ConsensusScope,
+    session::ConsensusConfig,
+    storage::ConsensusStorage,
+    types::CreateProposalRequest,
+};
+
+pub trait ConsensusServiceAPI<Scope, S, E>
+where
+    Scope: ConsensusScope,
+    S: ConsensusStorage<Scope>,
+    E: ConsensusEventBus<Scope>,
+{
+    fn create_proposal(
+        &self,
+        scope: &Scope,
+        request: CreateProposalRequest,
+    ) -> impl Future<Output = Result<Proposal, ConsensusError>> + Send;
+    fn create_proposal_with_config(
+        &self,
+        scope: &Scope,
+        request: CreateProposalRequest,
+        config: Option<ConsensusConfig>,
+    ) -> impl Future<Output = Result<Proposal, ConsensusError>> + Send;
+
+    fn cast_vote<SN: Signer + Sync + Send>(
+        &self,
+        scope: &Scope,
+        proposal_id: u32,
+        choice: bool,
+        signer: SN,
+    ) -> impl Future<Output = Result<Vote, ConsensusError>> + Send;
+    fn cast_vote_and_get_proposal<SN: Signer + Sync + Send>(
+        &self,
+        scope: &Scope,
+        proposal_id: u32,
+        choice: bool,
+        signer: SN,
+    ) -> impl Future<Output = Result<Proposal, ConsensusError>> + Send;
+
+    fn process_incoming_proposal(
+        &self,
+        scope: &Scope,
+        proposal: Proposal,
+    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+    fn process_incoming_vote(
+        &self,
+        scope: &Scope,
+        vote: Vote,
+    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+
+    fn get_proposal(
+        &self,
+        scope: &Scope,
+        proposal_id: u32,
+    ) -> impl Future<Output = Result<Proposal, ConsensusError>> + Send;
+    fn get_proposal_payload(
+        &self,
+        scope: &Scope,
+        proposal_id: u32,
+    ) -> impl Future<Output = Result<Vec<u8>, ConsensusError>> + Send;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod protos {
     }
 }
 
+pub mod api;
 pub mod error;
 pub mod events;
 pub mod scope;

--- a/src/protos/messages/v1/consensus.proto
+++ b/src/protos/messages/v1/consensus.proto
@@ -4,7 +4,7 @@ package consensus.v1;
 // Proposal represents a consensus proposal that needs voting
 message Proposal {
     string name = 10;                   // Proposal name
-    string payload = 11;                // Payload with the proposal data
+    bytes payload = 11;                // Payload with the proposal data
     uint32 proposal_id = 12;            // Unique identifier of the proposal
     bytes proposal_owner = 13;          // Public key of the creator 
     repeated Vote votes = 14;           // Vote list in the proposal

--- a/src/service.rs
+++ b/src/service.rs
@@ -10,7 +10,7 @@ use crate::{
     session::{ConsensusConfig, ConsensusSession, ConsensusState},
     storage::{ConsensusStorage, InMemoryConsensusStorage},
     types::{ConsensusEvent, SessionTransition},
-    utils::{calculate_consensus_result, has_sufficient_votes},
+    utils::{calculate_consensus_result, current_timestamp, has_sufficient_votes},
 };
 /// The main service that handles proposals, votes, and consensus.
 ///
@@ -147,6 +147,16 @@ where
         Ok(Some(result))
     }
 
+    /// Get the resolved per-proposal consensus configuration for an existing session.
+    pub async fn get_proposal_config(
+        &self,
+        scope: &Scope,
+        proposal_id: u32,
+    ) -> Result<ConsensusConfig, ConsensusError> {
+        let session = self.get_session(scope, proposal_id).await?;
+        Ok(session.config)
+    }
+
     /// Get all proposals that have reached consensus, along with their results.
     ///
     /// Returns a map from proposal ID to result (`true` for YES, `false` for NO).
@@ -270,6 +280,9 @@ where
         proposal: Option<&Proposal>,
     ) -> Result<ConsensusConfig, ConsensusError> {
         // 1. If explicit config override exists, use it as base
+        // NOTE: if a per-proposal override is provided, we should not stomp its timeout
+        // from the proposal's expiration fields (the caller explicitly chose it).
+        let has_explicit_override = proposal_override.is_some();
         let base_config = if let Some(override_config) = proposal_override {
             override_config
         } else if let Some(scope_config) = self.storage.get_scope_config(scope).await? {
@@ -280,8 +293,11 @@ where
 
         // 2. Apply proposal field overrides if proposal is provided
         if let Some(prop) = proposal {
-            // Calculate timeout from expiration_timestamp (absolute timestamp) - timestamp (creation time)
-            let timeout_seconds = if prop.expiration_timestamp > prop.timestamp {
+            // Calculate timeout from expiration_timestamp (absolute timestamp) - timestamp (creation time),
+            // unless an explicit override was supplied.
+            let timeout_seconds = if has_explicit_override {
+                base_config.consensus_timeout()
+            } else if prop.expiration_timestamp > prop.timestamp {
                 Duration::from_secs(prop.expiration_timestamp - prop.timestamp)
             } else {
                 base_config.consensus_timeout()
@@ -342,12 +358,19 @@ where
                     ConsensusEvent::ConsensusReached {
                         proposal_id,
                         result: consensus_result,
+                        timestamp: current_timestamp()?,
                     },
                 );
                 Ok(consensus_result)
             }
             None => {
-                self.emit_event(scope, ConsensusEvent::ConsensusFailed { proposal_id });
+                self.emit_event(
+                    scope,
+                    ConsensusEvent::ConsensusFailed {
+                        proposal_id,
+                        timestamp: current_timestamp()?,
+                    },
+                );
                 Err(ConsensusError::InsufficientVotesAtTimeout)
             }
         }
@@ -423,6 +446,7 @@ where
                 ConsensusEvent::ConsensusReached {
                     proposal_id,
                     result,
+                    timestamp: current_timestamp().unwrap_or(0),
                 },
             );
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,12 +6,16 @@ use crate::{
     utils::{current_timestamp, generate_id, validate_expected_voters_count, validate_timeout},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConsensusEvent {
     /// Consensus was reached! The proposal has a final result (yes or no).
-    ConsensusReached { proposal_id: u32, result: bool },
+    ConsensusReached {
+        proposal_id: u32,
+        result: bool,
+        timestamp: u64,
+    },
     /// Consensus failed - not enough votes were collected before the timeout.
-    ConsensusFailed { proposal_id: u32 },
+    ConsensusFailed { proposal_id: u32, timestamp: u64 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,7 +31,7 @@ pub struct CreateProposalRequest {
     /// A short name for the proposal (e.g., "Upgrade to v2").
     pub name: String,
     /// Additional details about what's being voted on.
-    pub payload: String,
+    pub payload: Vec<u8>,
     /// The address (public key bytes) of whoever created this proposal.
     pub proposal_owner: Vec<u8>,
     /// How many people are expected to vote (used to calculate consensus threshold).
@@ -42,7 +46,7 @@ impl CreateProposalRequest {
     /// Create a new proposal request with validation.
     pub fn new(
         name: String,
-        payload: String,
+        payload: Vec<u8>,
         proposal_owner: Vec<u8>,
         expected_voters_count: u32,
         expiration_timestamp: u64,

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -4,13 +4,13 @@ use std::{sync::Arc, time::Duration};
 use tokio::{spawn, sync::Barrier, time::sleep};
 
 use hashgraph_like_consensus::{
-    error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
-    session::ConsensusConfig, types::CreateProposalRequest,
+    api::ConsensusServiceAPI, error::ConsensusError, scope::ScopeID,
+    service::DefaultConsensusService, session::ConsensusConfig, types::CreateProposalRequest,
 };
 
 const SCOPE: &str = "concurrency_scope";
 const PROPOSAL_NAME: &str = "Concurrency Test";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 
 const EXPIRATION: u64 = 120;
 const EXPIRATION_WAIT_TIME: u64 = 100;
@@ -39,7 +39,7 @@ async fn test_concurrent_vote_casting() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_10,
                 EXPIRATION,
@@ -98,7 +98,7 @@ async fn test_concurrent_proposal_operations() {
                     &scope_clone,
                     CreateProposalRequest::new(
                         format!("Proposal {i}"),
-                        PROPOSAL_PAYLOAD.to_string(),
+                        PROPOSAL_PAYLOAD,
                         owner_bytes(&proposal_owner),
                         EXPECTED_VOTERS_COUNT_3,
                         EXPIRATION,
@@ -136,7 +136,7 @@ async fn test_concurrent_duplicate_vote_rejection() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,

--- a/tests/consensus_service_tests.rs
+++ b/tests/consensus_service_tests.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use hashgraph_like_consensus::{
+    api::ConsensusServiceAPI,
     error::ConsensusError,
     scope::ScopeID,
     service::DefaultConsensusService,
@@ -13,7 +14,7 @@ use hashgraph_like_consensus::{
 const SCOPE1_NAME: &str = "scope1";
 const SCOPE2_NAME: &str = "scope2";
 const PROPOSAL_NAME: &str = "Test Proposal";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 const PROPOSAL_EXPIRATION_TIME: u64 = 60;
 
 const EXPECTED_VOTERS_COUNT_4: u32 = 4;
@@ -38,7 +39,7 @@ async fn test_basic_consensus_flow() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 PROPOSAL_EXPIRATION_TIME,
@@ -107,7 +108,7 @@ async fn test_multi_scope_isolation() {
             &scope1,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&signer1),
                 EXPECTED_VOTERS_COUNT_2,
                 PROPOSAL_EXPIRATION_TIME,
@@ -129,7 +130,7 @@ async fn test_multi_scope_isolation() {
             &scope2,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&signer2),
                 EXPECTED_VOTERS_COUNT_1,
                 PROPOSAL_EXPIRATION_TIME,
@@ -178,7 +179,7 @@ async fn test_consensus_threshold_emits_event() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_4,
                 PROPOSAL_EXPIRATION_TIME,
@@ -210,6 +211,7 @@ async fn test_consensus_threshold_emits_event() {
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
                     result,
+                    timestamp: _event_timestamp,
                 } = event
                 && proposal_id == event_proposal_id
             {
@@ -237,7 +239,7 @@ async fn test_handle_consensus_timeout_already_reached() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_2,
                 PROPOSAL_EXPIRATION_TIME,
@@ -286,7 +288,7 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 PROPOSAL_EXPIRATION_TIME,
@@ -325,6 +327,7 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
                     result: event_result,
+                    timestamp: _event_timestamp,
                 } = event
                 && event_proposal_id == proposal.proposal_id
             {
@@ -353,7 +356,7 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_4,
                 PROPOSAL_EXPIRATION_TIME,
@@ -388,6 +391,7 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusFailed {
                     proposal_id: event_proposal_id,
+                    timestamp: _event_timestamp,
                 } = event
                 && event_proposal_id == proposal.proposal_id
             {
@@ -433,7 +437,7 @@ async fn test_handle_consensus_timeout_no_votes() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 PROPOSAL_EXPIRATION_TIME,
@@ -462,6 +466,7 @@ async fn test_handle_consensus_timeout_no_votes() {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusFailed {
                     proposal_id: event_proposal_id,
+                    timestamp: _event_timestamp,
                 } = event
                 && event_proposal_id == proposal.proposal_id
             {
@@ -506,7 +511,7 @@ async fn test_get_reached_proposals_with_consensus() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_1,
                 PROPOSAL_EXPIRATION_TIME,
@@ -560,7 +565,7 @@ async fn test_get_reached_proposals_no_consensus() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 PROPOSAL_EXPIRATION_TIME,
@@ -600,7 +605,7 @@ async fn test_get_reached_proposals_mixed_states() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner1),
                 EXPECTED_VOTERS_COUNT_1,
                 PROPOSAL_EXPIRATION_TIME,
@@ -623,7 +628,7 @@ async fn test_get_reached_proposals_mixed_states() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner2),
                 EXPECTED_VOTERS_COUNT_1,
                 PROPOSAL_EXPIRATION_TIME,
@@ -646,7 +651,7 @@ async fn test_get_reached_proposals_mixed_states() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 proposal_owner_from_signer(&proposal_owner3),
                 EXPECTED_VOTERS_COUNT_3,
                 PROPOSAL_EXPIRATION_TIME,

--- a/tests/network_gossip_tests.rs
+++ b/tests/network_gossip_tests.rs
@@ -2,13 +2,13 @@ use alloy::signers::local::PrivateKeySigner;
 use tokio::time::{Duration, sleep};
 
 use hashgraph_like_consensus::{
-    error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
-    session::ConsensusConfig, types::CreateProposalRequest,
+    api::ConsensusServiceAPI, error::ConsensusError, scope::ScopeID,
+    service::DefaultConsensusService, session::ConsensusConfig, types::CreateProposalRequest,
 };
 
 const SCOPE: &str = "network_gossip_scope";
 const PROPOSAL_NAME: &str = "Network Gossip Proposal";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 const EXPIRATION: u64 = 120;
 
 fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
@@ -29,7 +29,7 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner_a),
                 2, // n=2 => unanimous YES required
                 EXPIRATION,
@@ -97,7 +97,7 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner_a),
                 3,
                 EXPIRATION,
@@ -184,7 +184,7 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
             &scope,
             CreateProposalRequest::new(
                 "Timeout Proposal".to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner_a),
                 4,
                 EXPIRATION,
@@ -282,7 +282,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
             &scope,
             CreateProposalRequest::new(
                 "Timeout Tie Proposal".to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner_a),
                 4,
                 EXPIRATION,

--- a/tests/rfc_compliance_tests.rs
+++ b/tests/rfc_compliance_tests.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
 
 use hashgraph_like_consensus::{
+    api::ConsensusServiceAPI,
     error::ConsensusError,
     scope::ScopeID,
     service::DefaultConsensusService,
@@ -14,7 +15,7 @@ use hashgraph_like_consensus::{
 
 const SCOPE: &str = "rfc_compliance_scope";
 const PROPOSAL_NAME: &str = "RFC Compliance Test";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 
 const EXPIRATION: u64 = 120;
 const EXPIRATION_WAIT_TIME: u64 = 100;
@@ -46,7 +47,7 @@ async fn test_proposal_initialization_round_is_one() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
@@ -73,7 +74,7 @@ async fn test_round_increments_on_vote_p2p() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
@@ -126,7 +127,7 @@ async fn test_gossipsub_rounds_stay_at_two() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 5, // 5 expected voters, need 3 YES for consensus
                 EXPIRATION,
@@ -202,7 +203,7 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 12, // 12 expected voters
                 EXPIRATION,
@@ -260,7 +261,7 @@ async fn test_p2p_dynamic_max_rounds() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 9, // 9 expected voters, ceil(2n/3) = 6
                 EXPIRATION,
@@ -346,7 +347,7 @@ async fn test_p2p_ceil_calculation_edge_cases() {
                 &scope,
                 CreateProposalRequest::new(
                     format!("Test n={}", n),
-                    PROPOSAL_PAYLOAD.to_string(),
+                    PROPOSAL_PAYLOAD,
                     owner_bytes(&proposal_owner),
                     n,
                     EXPIRATION,
@@ -397,7 +398,7 @@ async fn test_gossipsub_batch_vote_processing() {
     // Create a proposal manually (simulating receiving from network)
     let request = CreateProposalRequest::new(
         PROPOSAL_NAME.to_string(),
-        PROPOSAL_PAYLOAD.to_string(),
+        PROPOSAL_PAYLOAD,
         owner_bytes(&proposal_owner),
         5,
         EXPIRATION,
@@ -465,7 +466,7 @@ async fn test_p2p_batch_vote_processing() {
     // Create a P2P proposal manually (simulating receiving from network)
     let request = CreateProposalRequest::new(
         PROPOSAL_NAME.to_string(),
-        PROPOSAL_PAYLOAD.to_string(),
+        PROPOSAL_PAYLOAD,
         owner_bytes(&proposal_owner),
         9, // ceil(2*9/3) = 6 votes max
         EXPIRATION,
@@ -550,7 +551,7 @@ async fn test_consensus_reachable_in_both_modes() {
             &scope1,
             CreateProposalRequest::new(
                 "Gossipsub Consensus".to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner1),
                 6, // Need 4 YES votes for consensus (>6/2 = >3)
                 EXPIRATION,
@@ -589,7 +590,7 @@ async fn test_consensus_reachable_in_both_modes() {
             &scope2,
             CreateProposalRequest::new(
                 "P2P Consensus".to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&owner2),
                 6, // Need 4 YES votes for consensus
                 EXPIRATION,
@@ -633,7 +634,7 @@ async fn test_n_le_2_requires_unanimous_yes() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_1,
                 EXPIRATION,
@@ -665,7 +666,7 @@ async fn test_n_le_2_requires_unanimous_yes() {
             &scope2,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner2),
                 EXPECTED_VOTERS_COUNT_2,
                 EXPIRATION,
@@ -703,7 +704,7 @@ async fn test_n_le_2_requires_unanimous_yes() {
             &scope3,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner3),
                 EXPECTED_VOTERS_COUNT_2,
                 EXPIRATION,
@@ -752,7 +753,7 @@ async fn test_n_gt_2_consensus_requirements() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
@@ -814,7 +815,7 @@ async fn test_expired_proposal_rejected() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION_1_SECOND,
@@ -851,7 +852,7 @@ async fn test_timestamp_replay_attack_protection() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
@@ -918,7 +919,7 @@ async fn test_equality_of_votes_handling() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_4,
                 EXPIRATION,
@@ -977,7 +978,7 @@ async fn test_equality_of_votes_handling() {
             &scope2,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner2),
                 EXPECTED_VOTERS_COUNT_4,
                 EXPIRATION,

--- a/tests/storage_stream_tests.rs
+++ b/tests/storage_stream_tests.rs
@@ -9,14 +9,14 @@ use hashgraph_like_consensus::{
 
 const SCOPE: &str = "stream_scope";
 const MISSING_SCOPE: &str = "missing_stream_scope";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 const EXPIRATION: u64 = 120;
 const EXPECTED_VOTERS_COUNT: u32 = 3;
 
 fn make_session(name: &str) -> ConsensusSession {
     let proposal = CreateProposalRequest::new(
         name.to_string(),
-        PROPOSAL_PAYLOAD.to_string(),
+        PROPOSAL_PAYLOAD,
         vec![1, 2, 3], // arbitrary "owner" bytes; signature not needed for storage tests
         EXPECTED_VOTERS_COUNT,
         EXPIRATION,

--- a/tests/vote_tests.rs
+++ b/tests/vote_tests.rs
@@ -1,6 +1,7 @@
 use alloy::signers::local::PrivateKeySigner;
 
 use hashgraph_like_consensus::{
+    api::ConsensusServiceAPI,
     scope::ScopeID,
     service::DefaultConsensusService,
     session::ConsensusConfig,
@@ -10,7 +11,7 @@ use hashgraph_like_consensus::{
 
 const SCOPE: &str = "vote_scope";
 const PROPOSAL_NAME: &str = "Vote Test Proposal";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 
 const EXPIRATION: u64 = 120;
 const EXPECTED_VOTERS_COUNT: u32 = 3;
@@ -33,7 +34,7 @@ async fn test_received_hash_for_new_voter() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT,
                 EXPIRATION,
@@ -80,7 +81,7 @@ async fn test_parent_hash_for_same_voter() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT,
                 EXPIRATION,

--- a/tests/vote_validation_tests.rs
+++ b/tests/vote_validation_tests.rs
@@ -3,6 +3,7 @@ use alloy::signers::{Signer, local::PrivateKeySigner};
 use prost::Message;
 
 use hashgraph_like_consensus::{
+    api::ConsensusServiceAPI,
     error::ConsensusError,
     scope::ScopeID,
     service::DefaultConsensusService,
@@ -13,7 +14,7 @@ use hashgraph_like_consensus::{
 
 const SCOPE: &str = "validation_scope";
 const PROPOSAL_NAME: &str = "Proposal";
-const PROPOSAL_PAYLOAD: &str = "";
+const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
 
 const EXPIRATION: u64 = 120;
 
@@ -38,7 +39,7 @@ async fn test_vote_created_with_helper_is_valid() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
@@ -77,7 +78,7 @@ async fn test_invalid_signature_is_rejected() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_2,
                 EXPIRATION,
@@ -126,7 +127,7 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
-                PROPOSAL_PAYLOAD.to_string(),
+                PROPOSAL_PAYLOAD,
                 owner_bytes(&proposal_owner),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,


### PR DESCRIPTION
- Add ConsensusServiceAPI trait defining the public contract
- Add get_proposal and get_proposal_payload methods
- Refactor Proposal payload from String to Vec<u8>
- Add get_proposal_config method to ConsensusService
- Enhance ConsensusConfig with new builder methods
- Add PartialEq/Eq to ConsensusEvent for testability
- Add timestamp to consensus events