### PR TITLE
test: Improve coverage 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /.vscode
 /.idea
+/.claude
+/docs
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Perfect for group governance, voting systems, or any scenario where you need dis
 - **Event-driven** - Subscribe to consensus outcomes via a broadcast event bus
 - **Cryptographic integrity** - Votes are signed with secp256k1 and chained in a hashgraph structure
 
-Based on the [Hashgraph-like Consensus Protocol RFC](https://github.com/vacp2p/rfc-index/blob/main/vac/raw/consensus-hashgraphlike.md).
+Based on the [Hashgraph-like Consensus Protocol RFC](https://lip.logos.co/ift-ts/raw/consensus-hashgraphlike.html).
 
 ## Installation
 
@@ -88,10 +88,10 @@ Scope (group / channel)
 
 ### Network Types
 
-| Type | Rounds | Behavior |
-|------|--------|----------|
-| **Gossipsub** (default) | Fixed 2 rounds | Round 1 = proposal broadcast, Round 2 = all votes |
-| **P2P** | Dynamic `ceil(2n/3)` | Each vote advances the round by one |
+| Type                    | Rounds               | Behavior                                          |
+| ----------------------- | -------------------- | ------------------------------------------------- |
+| **Gossipsub** (default) | Fixed 2 rounds       | Round 1 = proposal broadcast, Round 2 = all votes |
+| **P2P**                 | Dynamic `ceil(2n/3)` | Each vote advances the round by one               |
 
 ## API Reference
 
@@ -270,12 +270,12 @@ pub trait ConsensusEventBus<Scope> {
 
 The `utils` module provides low-level helpers:
 
-| Function | Description |
-|----------|-------------|
-| `validate_proposal()` | Validate a proposal and its votes |
-| `validate_vote()` | Verify a vote's signature and structure |
-| `validate_vote_chain()` | Ensure parent/received hash chains are correct |
-| `has_sufficient_votes()` | Quick threshold check (count-based) |
+| Function                       | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `validate_proposal()`          | Validate a proposal and its votes                                        |
+| `validate_vote()`              | Verify a vote's signature and structure                                  |
+| `validate_vote_chain()`        | Ensure parent/received hash chains are correct                           |
+| `has_sufficient_votes()`       | Quick threshold check (count-based)                                      |
 | `calculate_consensus_result()` | Determine result from collected votes using threshold and liveness rules |
 
 ## Building

--- a/src/session.rs
+++ b/src/session.rs
@@ -381,11 +381,13 @@ impl ConsensusSession {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use alloy::signers::local::PrivateKeySigner;
 
     use crate::{
         error::ConsensusError,
-        session::{ConsensusConfig, ConsensusSession},
+        session::{ConsensusConfig, ConsensusSession, ConsensusState},
         types::CreateProposalRequest,
         utils::build_vote,
     };
@@ -488,5 +490,114 @@ mod tests {
         let vote5 = build_vote(&session.proposal, true, signer5).await.unwrap();
         let err = session.add_vote(vote5).unwrap_err();
         assert!(matches!(err, ConsensusError::MaxRoundsExceeded));
+    }
+
+    #[test]
+    fn consensus_config_builder_and_getters_cover_edges() {
+        let cfg = ConsensusConfig::gossipsub()
+            .with_threshold(0.75)
+            .unwrap()
+            .with_timeout(Duration::from_secs(42))
+            .unwrap()
+            .with_liveness_criteria(false);
+
+        assert_eq!(cfg.consensus_threshold(), 0.75);
+        assert_eq!(cfg.consensus_timeout(), Duration::from_secs(42));
+        assert!(!cfg.liveness_criteria());
+
+        let err = ConsensusConfig::gossipsub()
+            .with_threshold(1.1)
+            .unwrap_err();
+        assert!(matches!(err, ConsensusError::InvalidConsensusThreshold));
+
+        let err = ConsensusConfig::gossipsub()
+            .with_timeout(Duration::from_secs(0))
+            .unwrap_err();
+        assert!(matches!(err, ConsensusError::InvalidTimeout));
+
+        // Covers max_round_limit branch when P2P-like mode uses explicit max_rounds (non-zero).
+        let explicit = ConsensusConfig::new(2.0 / 3.0, Duration::from_secs(60), 7, false, true);
+        assert_eq!(explicit.max_round_limit(100), 7);
+    }
+
+    #[tokio::test]
+    async fn add_vote_rejects_non_active_and_reports_reached_when_finalized() {
+        let signer = PrivateKeySigner::random();
+        let request = CreateProposalRequest::new(
+            "Test".into(),
+            "".into(),
+            signer.address().as_slice().to_vec(),
+            3,
+            60,
+            true,
+        )
+        .unwrap();
+        let proposal = request.into_proposal().unwrap();
+
+        // Failed sessions reject new votes.
+        let mut failed_session =
+            ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
+        failed_session.state = ConsensusState::Failed;
+        let vote = build_vote(&failed_session.proposal, true, signer.clone())
+            .await
+            .unwrap();
+        let err = failed_session.add_vote(vote).unwrap_err();
+        assert!(matches!(err, ConsensusError::SessionNotActive));
+
+        // Finalized sessions return existing transition/result.
+        let mut finalized_session = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
+        finalized_session.state = ConsensusState::ConsensusReached(true);
+        let vote = build_vote(&finalized_session.proposal, true, signer)
+            .await
+            .unwrap();
+        let transition = finalized_session.add_vote(vote).unwrap();
+        assert!(matches!(
+            transition,
+            crate::types::SessionTransition::ConsensusReached(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn initialize_with_votes_non_active_duplicate_and_zero_votes_paths() {
+        let signer = PrivateKeySigner::random();
+        let request = CreateProposalRequest::new(
+            "Test".into(),
+            "".into(),
+            signer.address().as_slice().to_vec(),
+            4,
+            60,
+            true,
+        )
+        .unwrap();
+        let proposal = request.into_proposal().unwrap();
+
+        // Non-active sessions reject initialization.
+        let mut inactive = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
+        inactive.state = ConsensusState::Failed;
+        let err = inactive
+            .initialize_with_votes(vec![], proposal.expiration_timestamp, proposal.timestamp)
+            .unwrap_err();
+        assert!(matches!(err, ConsensusError::SessionNotActive));
+
+        // Duplicate owners are rejected before chain/signature checks.
+        let mut dup_session = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
+        let vote1 = build_vote(&dup_session.proposal, true, signer.clone())
+            .await
+            .unwrap();
+        let vote2 = build_vote(&dup_session.proposal, false, signer)
+            .await
+            .unwrap();
+        let err = dup_session
+            .initialize_with_votes(
+                vec![vote1, vote2],
+                proposal.expiration_timestamp,
+                proposal.timestamp,
+            )
+            .unwrap_err();
+        assert!(matches!(err, ConsensusError::DuplicateVote));
+
+        // Explicitly exercise gossipsub projected round branch where vote_count == 0.
+        let mut zero_votes = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
+        zero_votes.check_round_limit(0).unwrap();
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -600,4 +600,65 @@ mod tests {
         let mut zero_votes = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
         zero_votes.check_round_limit(0).unwrap();
     }
+
+    #[test]
+    fn p2p_round_limit_should_reject_effectively_huge_vote_count() {
+        if usize::BITS <= 32 {
+            return;
+        }
+
+        let signer = PrivateKeySigner::random();
+        let request = CreateProposalRequest::new(
+            "TruncationTest".into(),
+            vec![],
+            signer.address().as_slice().to_vec(),
+            1,
+            60,
+            true,
+        )
+        .unwrap();
+
+        let proposal = request.into_proposal().unwrap();
+        let mut session = ConsensusSession::new(proposal, ConsensusConfig::p2p());
+
+        let wrapped_vote_count = (u32::MAX as usize) + 1;
+
+        // Desired behavior: an effectively huge batch must be rejected by round-limit checks.
+        let result = session.check_round_limit(wrapped_vote_count);
+        assert!(
+            result.is_err(),
+            "effectively huge vote_count should not pass round-limit checks"
+        );
+    }
+
+    #[test]
+    fn p2p_update_round_should_advance_for_effectively_huge_vote_count() {
+        if usize::BITS <= 32 {
+            return;
+        }
+
+        let signer = PrivateKeySigner::random();
+        let request = CreateProposalRequest::new(
+            "RoundUpdateTruncation".into(),
+            vec![],
+            signer.address().as_slice().to_vec(),
+            5,
+            60,
+            true,
+        )
+        .unwrap();
+
+        let proposal = request.into_proposal().unwrap();
+        let mut session = ConsensusSession::new(proposal, ConsensusConfig::p2p());
+        let starting_round = session.proposal.round;
+
+        let wrapped_vote_count = (u32::MAX as usize) + 1;
+        session.update_round(wrapped_vote_count);
+
+        // Desired behavior: adding a huge number of votes must advance round.
+        assert!(
+            session.proposal.round > starting_round,
+            "round should advance when a huge vote_count is applied"
+        );
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -264,6 +264,13 @@ impl ConsensusSession {
             }
         }
 
+        // Each distinct voter can vote at most once, so the batch size
+        // is bounded by expected_voters_count (u32). Reject early if violated.
+        if votes.len() > self.proposal.expected_voters_count as usize {
+            self.state = ConsensusState::Failed;
+            return Err(ConsensusError::MaxRoundsExceeded);
+        }
+
         validate_vote_chain(&votes)?;
         for vote in &votes {
             validate_vote(vote, expiration_timestamp, creation_time)?;
@@ -287,6 +294,12 @@ impl ConsensusSession {
     /// - For P2P: Calculates `(current_round - 1) + vote_count`.
     /// - For Gossipsub: Moves to Round 2 if `vote_count > 0`.
     fn check_round_limit(&mut self, vote_count: usize) -> Result<(), ConsensusError> {
+        // vote_count cannot exceed expected_voters_count (u32); reject if it does
+        if vote_count > self.proposal.expected_voters_count as usize {
+            self.state = ConsensusState::Failed;
+            return Err(ConsensusError::MaxRoundsExceeded);
+        }
+
         // Determine the value to compare against the limit based on configuration
         let projected_value = if self.config.use_gossipsub_rounds {
             // Gossipsub Logic:
@@ -303,6 +316,7 @@ impl ConsensusSession {
             // RFC Section 2.5.3: Round increments per vote.
             // Current existing votes = round - 1.
             // Projected total = Existing votes + New votes.
+            // vote_count is bounded by expected_voters_count (u32), safe to cast
             let current_votes = self.proposal.round.saturating_sub(1);
             current_votes.saturating_add(vote_count as u32)
         };
@@ -336,6 +350,7 @@ impl ConsensusSession {
         } else {
             // RFC Section 2.5.3: P2P
             // Round increments for every vote added.
+            // vote_count is bounded by expected_voters_count (u32), safe to cast
             self.proposal.round = self.proposal.round.saturating_add(vote_count as u32);
         }
     }
@@ -632,17 +647,13 @@ mod tests {
     }
 
     #[test]
-    fn p2p_update_round_should_advance_for_effectively_huge_vote_count() {
-        if usize::BITS <= 32 {
-            return;
-        }
-
+    fn p2p_update_round_should_advance_for_max_u32_vote_count() {
         let signer = PrivateKeySigner::random();
         let request = CreateProposalRequest::new(
-            "RoundUpdateTruncation".into(),
+            "RoundUpdateMax".into(),
             vec![],
             signer.address().as_slice().to_vec(),
-            5,
+            u32::MAX,
             60,
             true,
         )
@@ -652,13 +663,13 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, ConsensusConfig::p2p());
         let starting_round = session.proposal.round;
 
-        let wrapped_vote_count = (u32::MAX as usize) + 1;
-        session.update_round(wrapped_vote_count);
+        // vote_count at the u32 boundary should still advance the round via saturating_add
+        session.update_round(u32::MAX as usize);
 
-        // Desired behavior: adding a huge number of votes must advance round.
         assert!(
             session.proposal.round > starting_round,
-            "round should advance when a huge vote_count is applied"
+            "round should advance when max u32 vote_count is applied"
         );
+        assert_eq!(session.proposal.round, u32::MAX);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,3 +99,32 @@ impl CreateProposalRequest {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CreateProposalRequest;
+
+    #[test]
+    fn into_proposal_should_not_overflow_expiration_timestamp() {
+        let request = CreateProposalRequest::new(
+            "overflow-check".to_string(),
+            vec![],
+            vec![1u8; 20],
+            1,
+            u64::MAX,
+            true,
+        )
+        .expect("request should be valid");
+
+        // Desired behavior: proposal creation should not panic on overflow-prone input,
+        // and expiration should never be earlier than creation timestamp.
+        let proposal = request
+            .into_proposal()
+            .expect("proposal creation should handle large expiration safely");
+
+        assert!(
+            proposal.expiration_timestamp >= proposal.timestamp,
+            "expiration must not overflow below creation timestamp"
+        );
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,7 +94,7 @@ impl CreateProposalRequest {
             expected_voters_count: self.expected_voters_count,
             round: 1,
             timestamp: now,
-            expiration_timestamp: now + self.expiration_timestamp,
+            expiration_timestamp: now.saturating_add(self.expiration_timestamp),
             liveness_criteria_yes: self.liveness_criteria_yes,
         })
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -377,3 +377,30 @@ pub fn has_sufficient_votes(
     let required_votes = calculate_required_votes(expected_voters, consensus_threshold);
     total_votes >= required_votes
 }
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    #[test]
+    fn id_generation_should_not_collapse_distinct_128bit_values() {
+        let low = 0xDEADBEEFu32;
+        let high_a = 0x00000001u128;
+        let high_b = 0xABCDEF01u128;
+
+        let value_a = (high_a << 32) | (low as u128);
+        let value_b = (high_b << 32) | (low as u128);
+
+        let uuid_a = Uuid::from_u128(value_a);
+        let uuid_b = Uuid::from_u128(value_b);
+
+        let id_a = uuid_a.as_u128() as u32;
+        let id_b = uuid_b.as_u128() as u32;
+
+        // Desired behavior: distinct 128-bit values should remain distinct after conversion.
+        assert_ne!(
+            id_a, id_b,
+            "distinct 128-bit values should not collapse to the same 32-bit id"
+        );
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,10 +20,18 @@ use crate::{
 
 const SIGNATURE_LENGTH: usize = 65;
 
+/// Fold a 128-bit value into 32 bits via XOR so every bit contributes.
+fn fold_u128_to_u32(n: u128) -> u32 {
+    ((n >> 96) as u32) ^ ((n >> 64) as u32) ^ ((n >> 32) as u32) ^ (n as u32)
+}
+
 /// Generate a unique 32-bit ID from a UUID.
+///
+/// Uses XOR folding so all 128 bits of the UUID contribute to the result,
+/// avoiding collisions from simple truncation.
 pub fn generate_id() -> u32 {
     let uuid = Uuid::new_v4();
-    uuid.as_u128() as u32
+    fold_u128_to_u32(uuid.as_u128())
 }
 
 /// Compute the hash of a vote for signing and validation.
@@ -382,6 +390,8 @@ pub fn has_sufficient_votes(
 mod tests {
     use uuid::Uuid;
 
+    use super::fold_u128_to_u32;
+
     #[test]
     fn id_generation_should_not_collapse_distinct_128bit_values() {
         let low = 0xDEADBEEFu32;
@@ -394,8 +404,8 @@ mod tests {
         let uuid_a = Uuid::from_u128(value_a);
         let uuid_b = Uuid::from_u128(value_b);
 
-        let id_a = uuid_a.as_u128() as u32;
-        let id_b = uuid_b.as_u128() as u32;
+        let id_a = fold_u128_to_u32(uuid_a.as_u128());
+        let id_b = fold_u128_to_u32(uuid_b.as_u128());
 
         // Desired behavior: distinct 128-bit values should remain distinct after conversion.
         assert_ne!(

--- a/tests/consensus_service_tests.rs
+++ b/tests/consensus_service_tests.rs
@@ -2,6 +2,7 @@ use alloy::signers::Signer;
 use alloy::signers::local::PrivateKeySigner;
 use prost::Message;
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::timeout;
 
 use hashgraph_like_consensus::{
@@ -1187,6 +1188,85 @@ async fn test_handle_consensus_timeout_rejects_unknown_scope() {
     assert!(
         matches!(err, ConsensusError::SessionNotFound),
         "should return SessionNotFound for unknown scope"
+    );
+}
+
+#[tokio::test]
+async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
+    let service = DefaultConsensusService::default();
+    let mut events = service.subscribe_to_events();
+    let scope = ScopeID::from("still_active_no_event_scope");
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = setup_proposal(
+        &service,
+        &scope,
+        &proposal_owner,
+        EXPECTED_VOTERS_COUNT_4,
+        true,
+        ConsensusConfig::gossipsub(),
+    )
+    .await;
+
+    // One vote is insufficient for n=4; transition should remain StillActive.
+    service
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .await
+        .expect("vote should succeed");
+
+    let no_event = timeout(Duration::from_millis(150), events.recv()).await;
+    assert!(
+        no_event.is_err(),
+        "no terminal consensus event should be emitted while session is still active"
+    );
+}
+
+#[tokio::test]
+async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_expiration_not_after_timestamp()
+ {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from("resolve_config_base_timeout_scope");
+
+    let request = CreateProposalRequest::new(
+        PROPOSAL_NAME.to_string(),
+        PROPOSAL_PAYLOAD,
+        vec![1u8; 20],
+        EXPECTED_VOTERS_COUNT_3,
+        PROPOSAL_EXPIRATION_TIME,
+        false, // ensure liveness comes from proposal fields
+    )
+    .expect("valid proposal request");
+
+    let mut incoming = request.into_proposal().expect("proposal");
+
+    // Force expiration_timestamp <= timestamp while keeping both in the future,
+    // so proposal remains non-expired but resolve_config must fall back to base timeout.
+    let future = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs()
+        + 120;
+    incoming.timestamp = future;
+    incoming.expiration_timestamp = future;
+
+    service
+        .process_incoming_proposal(&scope, incoming.clone())
+        .await
+        .expect("incoming proposal should be accepted");
+
+    let resolved = service
+        .get_proposal_config(&scope, incoming.proposal_id)
+        .await
+        .expect("resolved config");
+
+    assert_eq!(
+        resolved.consensus_timeout(),
+        ConsensusConfig::gossipsub().consensus_timeout(),
+        "timeout should use base config when expiration_timestamp <= timestamp"
+    );
+    assert!(
+        !resolved.liveness_criteria(),
+        "liveness criteria should still be sourced from proposal fields"
     );
 }
 

--- a/tests/scope_config_tests.rs
+++ b/tests/scope_config_tests.rs
@@ -286,3 +286,92 @@ async fn create_proposal_with_config_preserves_override_timeout() {
 
     assert_eq!(resolved.consensus_timeout(), Duration::from_secs(120));
 }
+
+#[tokio::test]
+async fn test_scope_config_convenience_profiles_and_network_defaults() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from("convenience_profiles_scope");
+
+    // Ensure strict profile is applied and persists through initialize.
+    service
+        .scope(&scope)
+        .await
+        .unwrap()
+        .strict_consensus()
+        .initialize()
+        .await
+        .unwrap();
+
+    let strict = service.scope(&scope).await.unwrap().get_config();
+    assert_eq!(strict.default_consensus_threshold, 0.9);
+
+    // Ensure fast profile updates threshold+timeout.
+    service
+        .scope(&scope)
+        .await
+        .unwrap()
+        .fast_consensus()
+        .update()
+        .await
+        .unwrap();
+
+    let fast = service.scope(&scope).await.unwrap().get_config();
+    assert_eq!(fast.default_consensus_threshold, 0.6);
+    assert_eq!(fast.default_timeout, Duration::from_secs(30));
+
+    // Exercise both branches of with_network_defaults.
+    service
+        .scope(&scope)
+        .await
+        .unwrap()
+        .with_network_defaults(NetworkType::P2P)
+        .update()
+        .await
+        .unwrap();
+
+    let p2p = service.scope(&scope).await.unwrap().get_config();
+    assert_eq!(p2p.network_type, NetworkType::P2P);
+
+    service
+        .scope(&scope)
+        .await
+        .unwrap()
+        .with_network_defaults(NetworkType::Gossipsub)
+        .update()
+        .await
+        .unwrap();
+
+    let gossipsub = service.scope(&scope).await.unwrap().get_config();
+    assert_eq!(gossipsub.network_type, NetworkType::Gossipsub);
+}
+
+#[test]
+fn test_scope_config_builder_with_config_and_from_existing() {
+    use hashgraph_like_consensus::scope_config::ScopeConfig;
+
+    let existing = ScopeConfig::from(NetworkType::P2P);
+    let replacement = ScopeConfig {
+        network_type: NetworkType::Gossipsub,
+        default_consensus_threshold: 0.8,
+        default_timeout: Duration::from_secs(90),
+        default_liveness_criteria_yes: false,
+        max_rounds_override: Some(7),
+    };
+
+    let built = hashgraph_like_consensus::scope_config::ScopeConfigBuilder::from_existing(existing)
+        .with_config(replacement.clone())
+        .build()
+        .expect("replacement config should be valid");
+
+    assert_eq!(built.network_type, replacement.network_type);
+    assert_eq!(
+        built.default_consensus_threshold,
+        replacement.default_consensus_threshold
+    );
+    assert_eq!(built.default_timeout, replacement.default_timeout);
+    assert_eq!(
+        built.default_liveness_criteria_yes,
+        replacement.default_liveness_criteria_yes
+    );
+    assert_eq!(built.max_rounds_override, replacement.max_rounds_override);
+}

--- a/tests/storage_stream_tests.rs
+++ b/tests/storage_stream_tests.rs
@@ -74,3 +74,193 @@ async fn test_stream_scope_sessions_missing_scope_is_empty() {
         .await;
     assert!(items.is_empty());
 }
+
+#[tokio::test]
+async fn test_remove_list_scopes_and_replace_scope_sessions() {
+    let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
+    let scope = ScopeID::from("remove_replace_scope");
+
+    // Empty storage should return None for scopes and scope sessions.
+    assert!(storage.list_scopes().await.expect("list scopes").is_none());
+    assert!(
+        storage
+            .list_scope_sessions(&scope)
+            .await
+            .expect("list scope sessions")
+            .is_none()
+    );
+
+    // Save one session and ensure scope appears.
+    let session = make_session("remove-target");
+    let proposal_id = session.proposal.proposal_id;
+    storage
+        .save_session(&scope, session.clone())
+        .await
+        .expect("save session");
+
+    let scopes = storage
+        .list_scopes()
+        .await
+        .expect("list scopes")
+        .expect("should have one scope");
+    assert_eq!(scopes, vec![scope.clone()]);
+
+    // Remove existing and then missing session.
+    let removed = storage
+        .remove_session(&scope, proposal_id)
+        .await
+        .expect("remove existing");
+    assert!(removed.is_some());
+
+    let removed_missing = storage
+        .remove_session(&scope, proposal_id)
+        .await
+        .expect("remove missing");
+    assert!(removed_missing.is_none());
+
+    // Replace scope sessions with two entries and verify retrieval.
+    let replacement1 = make_session("replacement1");
+    let replacement2 = make_session("replacement2");
+    storage
+        .replace_scope_sessions(&scope, vec![replacement1.clone(), replacement2.clone()])
+        .await
+        .expect("replace scope sessions");
+
+    let listed = storage
+        .list_scope_sessions(&scope)
+        .await
+        .expect("list after replace")
+        .expect("scope must exist after replace");
+    assert_eq!(listed.len(), 2);
+}
+
+#[tokio::test]
+async fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths() {
+    let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
+    let scope = ScopeID::from("update_scope_sessions_scope");
+
+    let session = make_session("updatable");
+    let proposal_id = session.proposal.proposal_id;
+    storage
+        .save_session(&scope, session)
+        .await
+        .expect("save session");
+
+    // update_session success path.
+    let updated_name = storage
+        .update_session(&scope, proposal_id, |session| {
+            session.proposal.name = "mutated".to_string();
+            Ok(session.proposal.name.clone())
+        })
+        .await
+        .expect("update session");
+    assert_eq!(updated_name, "mutated");
+
+    // update_session missing path.
+    let err = storage
+        .update_session(&scope, u32::MAX, |_session| Ok(()))
+        .await
+        .expect_err("missing session should fail");
+    assert!(matches!(
+        err,
+        hashgraph_like_consensus::error::ConsensusError::SessionNotFound
+    ));
+
+    // update_scope_sessions mutator error path should surface error.
+    let err = storage
+        .update_scope_sessions(&scope, |_sessions| {
+            Err(hashgraph_like_consensus::error::ConsensusError::ConsensusFailed)
+        })
+        .await
+        .expect_err("mutator error should bubble up");
+    assert!(matches!(
+        err,
+        hashgraph_like_consensus::error::ConsensusError::ConsensusFailed
+    ));
+
+    // update_scope_sessions empty vector path should remove scope entry.
+    storage
+        .update_scope_sessions(&scope, |sessions| {
+            sessions.clear();
+            Ok(())
+        })
+        .await
+        .expect("cleanup update");
+
+    assert!(
+        storage
+            .list_scope_sessions(&scope)
+            .await
+            .expect("list after cleanup")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn test_scope_config_storage_validation_and_updates() {
+    use hashgraph_like_consensus::{
+        error::ConsensusError,
+        scope_config::{NetworkType, ScopeConfig},
+    };
+
+    let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
+    let scope = ScopeID::from("scope_config_storage_scope");
+
+    assert!(
+        storage
+            .get_scope_config(&scope)
+            .await
+            .expect("get config")
+            .is_none()
+    );
+
+    // set_scope_config validation failure path.
+    let invalid = ScopeConfig {
+        network_type: NetworkType::Gossipsub,
+        default_consensus_threshold: 2.0 / 3.0,
+        default_timeout: std::time::Duration::from_secs(60),
+        default_liveness_criteria_yes: true,
+        max_rounds_override: Some(0),
+    };
+    let err = storage
+        .set_scope_config(&scope, invalid)
+        .await
+        .expect_err("invalid config should fail");
+    assert!(matches!(err, ConsensusError::InvalidMaxRounds));
+
+    // update_scope_config creates default when missing and persists valid change.
+    storage
+        .update_scope_config(&scope, |config| {
+            config.network_type = NetworkType::P2P;
+            config.max_rounds_override = Some(0);
+            Ok(())
+        })
+        .await
+        .expect("update scope config");
+
+    let cfg = storage
+        .get_scope_config(&scope)
+        .await
+        .expect("get updated config")
+        .expect("config should exist");
+    assert_eq!(cfg.network_type, NetworkType::P2P);
+    assert_eq!(cfg.max_rounds_override, Some(0));
+
+    // updater error path.
+    let err = storage
+        .update_scope_config(&scope, |_config| Err(ConsensusError::ConsensusFailed))
+        .await
+        .expect_err("updater error should fail");
+    assert!(matches!(err, ConsensusError::ConsensusFailed));
+
+    // post-update validation failure path.
+    let err = storage
+        .update_scope_config(&scope, |config| {
+            config.network_type = NetworkType::Gossipsub;
+            config.max_rounds_override = Some(0);
+            Ok(())
+        })
+        .await
+        .expect_err("invalid updated config should fail validation");
+    assert!(matches!(err, ConsensusError::InvalidMaxRounds));
+}

--- a/tests/vote_validation_tests.rs
+++ b/tests/vote_validation_tests.rs
@@ -28,6 +28,21 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
     signer.address().as_slice().to_vec()
 }
 
+async fn resign_vote(
+    vote: &mut hashgraph_like_consensus::protos::consensus::v1::Vote,
+    signer: &PrivateKeySigner,
+) {
+    vote.vote_hash = compute_vote_hash(vote);
+    vote.signature.clear();
+    let vote_bytes = vote.encode_to_vec();
+    vote.signature = signer
+        .sign_message(&vote_bytes)
+        .await
+        .expect("vote should be resignable")
+        .as_bytes()
+        .to_vec();
+}
+
 #[tokio::test]
 async fn test_vote_created_with_helper_is_valid() {
     let service = DefaultConsensusService::default();
@@ -174,4 +189,195 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
         matches!(err, ConsensusError::ReceivedHashMismatch),
         "error: {err:?}"
     );
+}
+
+#[tokio::test]
+async fn test_validate_proposal_rejects_empty_vote_owner() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from(SCOPE);
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                PROPOSAL_NAME.to_string(),
+                PROPOSAL_PAYLOAD,
+                owner_bytes(&proposal_owner),
+                EXPECTED_VOTERS_COUNT_2,
+                EXPIRATION,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal");
+
+    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+        .await
+        .expect("vote");
+    vote.vote_owner.clear();
+
+    let mut invalid = proposal;
+    invalid.votes.push(vote);
+
+    let err = validate_proposal(&invalid).expect_err("empty vote owner should fail");
+    assert!(matches!(err, ConsensusError::EmptyVoteOwner));
+}
+
+#[tokio::test]
+async fn test_validate_proposal_rejects_empty_vote_hash() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from(SCOPE);
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                PROPOSAL_NAME.to_string(),
+                PROPOSAL_PAYLOAD,
+                owner_bytes(&proposal_owner),
+                EXPECTED_VOTERS_COUNT_2,
+                EXPIRATION,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal");
+
+    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+        .await
+        .expect("vote");
+    vote.vote_hash.clear();
+
+    let mut invalid = proposal;
+    invalid.votes.push(vote);
+
+    let err = validate_proposal(&invalid).expect_err("empty vote hash should fail");
+    assert!(matches!(err, ConsensusError::EmptyVoteHash));
+}
+
+#[tokio::test]
+async fn test_validate_proposal_rejects_empty_signature() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from(SCOPE);
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                PROPOSAL_NAME.to_string(),
+                PROPOSAL_PAYLOAD,
+                owner_bytes(&proposal_owner),
+                EXPECTED_VOTERS_COUNT_2,
+                EXPIRATION,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal");
+
+    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+        .await
+        .expect("vote");
+    vote.signature.clear();
+
+    let mut invalid = proposal;
+    invalid.votes.push(vote);
+
+    let err = validate_proposal(&invalid).expect_err("empty signature should fail");
+    assert!(matches!(err, ConsensusError::EmptySignature));
+}
+
+#[tokio::test]
+async fn test_validate_proposal_rejects_mismatched_signature_length() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from(SCOPE);
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                PROPOSAL_NAME.to_string(),
+                PROPOSAL_PAYLOAD,
+                owner_bytes(&proposal_owner),
+                EXPECTED_VOTERS_COUNT_2,
+                EXPIRATION,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal");
+
+    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+        .await
+        .expect("vote");
+    vote.signature = vec![7; 64];
+
+    let mut invalid = proposal;
+    invalid.votes.push(vote);
+
+    let err = validate_proposal(&invalid).expect_err("invalid signature length should fail");
+    assert!(matches!(
+        err,
+        ConsensusError::MismatchedLength {
+            expect: 65,
+            actual: 64
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
+    let service = DefaultConsensusService::default();
+    let scope = ScopeID::from(SCOPE);
+    let proposal_owner = PrivateKeySigner::random();
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                PROPOSAL_NAME.to_string(),
+                PROPOSAL_PAYLOAD,
+                owner_bytes(&proposal_owner),
+                EXPECTED_VOTERS_COUNT_3,
+                EXPIRATION,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal");
+
+    let voter_one = PrivateKeySigner::random();
+    let voter_two = PrivateKeySigner::random();
+
+    let vote_one = build_vote(&proposal, VOTE_YES, voter_one)
+        .await
+        .expect("vote one");
+    let mut vote_two = build_vote(&proposal, VOTE_NO, voter_two.clone())
+        .await
+        .expect("vote two");
+
+    // parent_hash points to another owner's vote, which should fail RFC parent-chain checks.
+    vote_two.parent_hash = vote_one.vote_hash.clone();
+    resign_vote(&mut vote_two, &voter_two).await;
+
+    let mut invalid = proposal;
+    invalid.votes.push(vote_one);
+    invalid.votes.push(vote_two);
+
+    let err = validate_proposal(&invalid).expect_err("parent hash owner mismatch should fail");
+    assert!(matches!(err, ConsensusError::ParentHashMismatch));
 }


### PR DESCRIPTION
A batch of tests to improve coverage for session, scope_config and storage_stream modules. Address problematic parts of code prone to large inputs handling or silent change of variable scale. 


## Tests modified/added

- test_cast_vote_still_active_does_not_emit_consensus_event
- test_process_incoming_proposal_resolve_config_uses_base_timeout_when_expiration_not_after_timestamp
- test_scope_config_convenience_profiles_and_network_defaults
- test_scope_config_builder_with_config_and_from_existing
- test_remove_list_scopes_and_replace_scope_sessions
- test_update_session_and_update_scope_sessions_error_and_cleanup_paths
- test_scope_config_storage_validation_and_updates
- test_validate_proposal_rejects_empty_vote_owner
- test_validate_proposal_rejects_empty_vote_hash
- test_validate_proposal_rejects_empty_signature
- test_validate_proposal_rejects_mismatched_signature_length
- test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch
- id_generation_should_not_collapse_distinct_128bit_values
- into_proposal_should_not_overflow_expiration_timestamp
- consensus_config_builder_and_getters_cover_edges
- add_vote_rejects_non_active_and_reports_reached_when_finalized
- initialize_with_votes_non_active_duplicate_and_zero_votes_paths
- p2p_round_limit_should_reject_effectively_huge_vote_count
- p2p_update_round_should_advance_for_effectively_huge_vote_count

## Issues reported
- https://github.com/vacp2p/hashgraph-like-consensus/issues/11

