### PR TITLE
feat(signing)!: introduce pluggable ConsensusSignatureScheme trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+## 0.3.0
+
+**Breaking** — the crate is no longer hard-coded to Ethereum signing.
+
+### Added
+
+- New [`signing`](src/signing.rs) module with a single
+  `ConsensusSignatureScheme` trait. Each peer implements it for signing
+  (`identity`, `sign`) and the same type's static `verify` method is used by
+  the service to validate incoming votes. Embedders can plug in Ed25519,
+  HSM-backed signers, libchat accounts, or any other scheme without forking
+  the crate.
+- `signing::ConsensusSchemeError` — a `thiserror`-based enum with `Sign` and
+  `Verify` variants, returned by both scheme operations. Implementors
+  construct variants directly (e.g. `ConsensusSchemeError::Sign(msg)`).
+- `signing::EthereumConsensusSigner` provides the default ECDSA-secp256k1
+  implementation matching the historical behavior of the crate. It wraps an
+  `alloy::signers::local::PrivateKeySigner` and verifies via recoverable
+  signature recovery against 20-byte addresses.
+- New `tests/custom_scheme_tests.rs` exercises the generic path end-to-end
+  with a non-Ethereum stub scheme.
+
+### Changed
+
+- `ConsensusService` now has a fourth generic parameter `Signer:
+  ConsensusSignatureScheme` carried as `PhantomData`. The scheme is selected
+  at construction (typically via the `DefaultConsensusService` alias for
+  Ethereum, or by spelling out the type explicitly for custom schemes).
+- `cast_vote` / `cast_vote_and_get_proposal` now take `signer: Signer` instead of a
+  bare `alloy_signer::Signer` — the signer must impl the scheme the service
+  is parameterized over.
+- `utils::build_vote`, `utils::validate_proposal`, and
+  `utils::validate_vote` are generic over the scheme; downstream callers
+  pick a type at the call site (turbofish or inference).
+- `ConsensusSession::from_proposal` / `initialize_with_votes` accept the
+  scheme as a generic parameter instead of receiving an explicit verifier.
+
+### Removed
+
+- The hard-coded `SIGNATURE_LENGTH` constant and 65-byte signature assumption
+  in `utils.rs`. Length and format are now scheme-specific.
+- `ConsensusError::MismatchedLength` and `ConsensusError::InvalidSignature`
+  variants. Scheme-specific length/encoding errors surface as
+  `ConsensusError::FailedToVerifyVote(ConsensusVerifyError)`.
+- `From<alloy_signer::Error>` for `ConsensusError`. Sign failures now go
+  through `ConsensusSignError` (wrapping any concrete error type).
+
+### Migration
+
+If you previously did:
+
+```rust
+use alloy::signers::local::PrivateKeySigner;
+use hashgraph_like_consensus::service::DefaultConsensusService;
+
+let service = DefaultConsensusService::default();
+let signer = PrivateKeySigner::random();
+service.cast_vote(&scope, proposal_id, true, signer).await?;
+```
+
+Wrap the signer in `EthereumConsensusSigner`:
+
+```rust
+use alloy::signers::local::PrivateKeySigner;
+use hashgraph_like_consensus::{
+    service::DefaultConsensusService,
+    signing::EthereumConsensusSigner,
+};
+
+let service = DefaultConsensusService::default();
+let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+service.cast_vote(&scope, proposal_id, true, signer).await?;
+```
+
+If you call `validate_proposal` directly, add a turbofish:
+
+```rust
+use hashgraph_like_consensus::{signing::EthereumConsensusSigner, utils::validate_proposal};
+
+validate_proposal::<EthereumConsensusSigner>(&proposal)?;
+```
+
+## 0.2.0
+
+- Removed the `ConsensusServiceAPI` trait.
+- Timeout liveness fix.
+- Storage query defaults.
+- Visibility cleanup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1",
  "serde",
  "serde_json",
@@ -117,14 +117,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "once_cell",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -347,7 +349,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror",
 ]
 
@@ -630,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -640,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -650,7 +652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -822,6 +824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -899,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -917,11 +928,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -970,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crunchy"
@@ -1267,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1488,13 +1500,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashgraph-like-consensus"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-signer",
@@ -1630,7 +1642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1670,10 +1682,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1703,13 +1717,28 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
+checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "leb128fmt"
@@ -1719,9 +1748,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2124,9 +2153,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2282,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -2299,7 +2328,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand 0.9.4",
  "rlp",
  "ruint-macro",
@@ -2427,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -2510,11 +2539,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2529,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2562,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -2572,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
+checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2773,10 +2803,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2818,7 +2863,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2827,7 +2872,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -2863,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -2949,11 +2994,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2962,14 +3007,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2980,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2990,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3003,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3123,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -3138,6 +3183,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashgraph-like-consensus"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "A lightweight Rust library for making binary decisions in networks using hashgraph-style consensus"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Perfect for group governance, voting systems, or any scenario where you need dis
 - **Fast** - Reaches consensus in O(log n) rounds
 - **Byzantine fault tolerant** - Correct even if up to 1/3 of peers are malicious
 - **Pluggable storage** - In-memory by default; implement `ConsensusStorage` for persistence
+- **Pluggable signing** - Default ECDSA-secp256k1 via `EthereumConsensusSigner`; implement `ConsensusSignatureScheme` for Ed25519, HSMs, or any custom scheme
 - **Network-agnostic** - Works with both Gossipsub (fixed 2-round) and P2P (dynamic rounds) topologies
 - **Event-driven** - Subscribe to consensus outcomes via a broadcast event bus
-- **Cryptographic integrity** - Votes are signed with secp256k1 and chained in a hashgraph structure
+- **Cryptographic integrity** - Votes are signed and chained in a hashgraph structure
 
 Based on the [Hashgraph-like Consensus Protocol RFC](https://lip.logos.co/ift-ts/raw/consensus-hashgraphlike.html).
 
@@ -34,6 +35,7 @@ hashgraph-like-consensus = { git = "https://github.com/vacp2p/hashgraph-like-con
 use hashgraph_like_consensus::{
     scope::ScopeID,
     service::DefaultConsensusService,
+    signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
     types::CreateProposalRequest,
 };
 use alloy::signers::local::PrivateKeySigner;
@@ -42,7 +44,7 @@ use alloy::signers::local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = DefaultConsensusService::default();
     let scope = ScopeID::from("example-scope");
-    let signer = PrivateKeySigner::random();
+    let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
 
     // Create a proposal
     let proposal = service
@@ -51,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             CreateProposalRequest::new(
                 "Upgrade contract".into(),   // name
                 b"Switch to v2".to_vec(),     // payload (bytes)
-                signer.address().as_slice().to_vec(), // owner
+                signer.identity().to_vec(),  // owner
                 3,                           // expected voters
                 60,                          // expiration (seconds from now)
                 true,                        // liveness: silent peers count as YES at timeout
@@ -96,10 +98,11 @@ Scope (group / channel)
 ### Architecture
 
 `ConsensusService` is the single entry point. All consensus business logic
-lives there. It is generic over two pluggable backends:
+lives there. It is generic over three pluggable backends:
 
 - `ConsensusStorage` — where sessions and votes are persisted (in-memory, database, etc.)
 - `ConsensusEventBus` — how consensus events are delivered (broadcast channel, message queue, etc.)
+- `ConsensusSignatureScheme` — how votes are signed and verified (ECDSA-secp256k1 by default, or your own scheme)
 
 Use `service.storage()` for reads, queries, and cleanup.
 Use `service.event_bus()` for event subscription.
@@ -115,7 +118,7 @@ orchestration. Your application is responsible for:
 | **Network propagation**              | The library performs no I/O. When you create a proposal or cast a vote, you must gossip it to peers yourself. When a message arrives from the network, call `process_incoming_proposal` or `process_incoming_vote`.                                |
 | **Timeout scheduling**               | The library does not spawn timers. You must schedule a timer for each proposal (using `consensus_timeout()` from the config) and call `handle_consensus_timeout` when it fires. Without this, proposals with offline voters stay `Active` forever. |
 | **`expected_voters_count` accuracy** | This value drives all threshold math (`ceil(2n/3)` quorum, silent peer counting). If it doesn't match the actual group size, consensus results will be wrong.                                                                                      |
-| **Signer management**                | You provide the private key signer when casting a vote. The library derives the voter identity from it. Each signer may vote at most once per proposal.                                                                                            |
+| **Signer management**                | You provide a `ConsensusSignatureScheme` value when casting a vote (e.g. `EthereumConsensusSigner::new(private_key)`). The library uses `identity()` for the voter address. Each identity may vote at most once per proposal.                       |
 | **Proposal ID tracking**             | The library generates a `proposal_id` on creation. You must store it and pass it to every subsequent call (`cast_vote`, `handle_consensus_timeout`, etc.).                                                                                         |
 | **Session eviction awareness**       | The default service keeps at most 10 sessions per scope (configurable via `new_with_max_sessions`). Older sessions are silently dropped when the limit is exceeded. Archive results before they are evicted.                                       |
 
@@ -124,16 +127,19 @@ orchestration. Your application is responsible for:
 ### Creating a Service
 
 ```rust
-use hashgraph_like_consensus::service::DefaultConsensusService;
+use hashgraph_like_consensus::service::{ConsensusService, DefaultConsensusService};
 
-// Default: in-memory storage, 10 max sessions per scope
+// Default: in-memory storage, broadcast events, EthereumConsensusSigner scheme,
+// 10 max sessions per scope
 let service = DefaultConsensusService::default();
 
-// Custom session limit
+// Custom session limit (still the Ethereum default scheme)
 let service = DefaultConsensusService::new_with_max_sessions(20);
 
-// Fully custom: plug in your own storage and event bus
-let service = ConsensusService::new_with_components(my_storage, my_event_bus, 10);
+// Fully custom: plug in your own storage, event bus, and signature scheme
+// (the scheme is picked via the type — typically via a type alias)
+let service: ConsensusService<MyScope, MyStorage, MyEvents, MyScheme> =
+    ConsensusService::new_with_components(my_storage, my_event_bus, 10);
 ```
 
 ### Configuring a Scope
@@ -201,15 +207,20 @@ service.process_incoming_proposal(&scope, proposal).await?;
 ### Casting and Processing Votes
 
 ```rust
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
+use alloy::signers::local::PrivateKeySigner;
+
+let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+
 // Cast your vote (yes = true, no = false)
-let vote = service.cast_vote(&scope, proposal_id, true, signer).await?;
+let vote = service.cast_vote(&scope, proposal_id, true, signer.clone()).await?;
 
 // Cast a vote and get the updated proposal (useful for gossiping)
 let proposal = service
     .cast_vote_and_get_proposal(&scope, proposal_id, true, signer)
     .await?;
 
-// Process a vote received from the network
+// Process a vote received from the network (uses the service's scheme to verify)
 service.process_incoming_vote(&scope, vote).await?;
 ```
 
@@ -342,17 +353,71 @@ pub trait ConsensusEventBus<Scope> {
 }
 ```
 
+### Custom Signature Scheme
+
+The default `EthereumConsensusSigner` uses ECDSA-secp256k1 with 20-byte
+Ethereum addresses, matching the historical behavior of the crate. To
+integrate Ed25519, an HSM, or any other scheme, implement
+`ConsensusSignatureScheme`:
+
+```rust
+use hashgraph_like_consensus::signing::{
+    ConsensusSchemeError, ConsensusSignatureScheme,
+};
+
+pub trait ConsensusSignatureScheme: Send + Sync {
+    /// Identity bytes written into `Vote::vote_owner` (address, public key, etc.).
+    fn identity(&self) -> &[u8];
+
+    /// Sign a payload. Returns raw signature bytes (length scheme-specific).
+    fn sign(&self, payload: &[u8])
+        -> impl Future<Output = Result<Vec<u8>, ConsensusSchemeError>> + Send;
+
+    /// Static verification — no instance needed. The service calls this for
+    /// every incoming vote.
+    fn verify(identity: &[u8], payload: &[u8], signature: &[u8])
+        -> Result<bool, ConsensusSchemeError>;
+}
+```
+
+The same type plays both roles: a value carries private state for signing,
+and the type itself is used statically by the service for verification. All
+peers on a network must agree on the scheme type. Pick it at service
+construction:
+
+```rust
+use hashgraph_like_consensus::{
+    events::BroadcastEventBus,
+    scope::ScopeID,
+    service::ConsensusService,
+    storage::InMemoryConsensusStorage,
+};
+
+type MyService = ConsensusService<
+    ScopeID,
+    InMemoryConsensusStorage<ScopeID>,
+    BroadcastEventBus<ScopeID>,
+    MyScheme,  // <- your ConsensusSignatureScheme impl
+>;
+```
+
+See `tests/custom_scheme_tests.rs` for a working non-Ethereum example.
+
 ### Utility Functions
 
 The `utils` module provides low-level helpers for advanced use cases:
 
-| Function                       | Description                                                              |
-| ------------------------------ | ------------------------------------------------------------------------ |
-| `build_vote()`                 | Create a signed vote linked into the hashgraph chain                     |
-| `compute_vote_hash()`          | Compute the deterministic hash of a vote                                 |
-| `validate_proposal()`          | Validate a proposal and all its votes                                    |
-| `calculate_consensus_result()` | Determine result from collected votes using threshold and liveness rules |
-| `has_sufficient_votes()`       | Quick threshold check (count-based)                                      |
+| Function                              | Description                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `build_vote::<Signer>()`              | Create a signed vote linked into the hashgraph chain                     |
+| `compute_vote_hash()`                 | Compute the deterministic hash of a vote                                 |
+| `validate_proposal::<Signer>()`       | Validate a proposal and all its votes against a signature scheme         |
+| `calculate_consensus_result()`        | Determine result from collected votes using threshold and liveness rules |
+| `has_sufficient_votes()`              | Quick threshold check (count-based)                                      |
+
+The generic `Signer` parameter on `build_vote` / `validate_proposal` /
+`validate_vote` selects which `ConsensusSignatureScheme` to use; pick it via
+turbofish or inference at the call site.
 
 ## Building
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 //! configuration validation, vote/proposal validation, session state, and
 //! consensus result categories.
 
-use alloy::primitives::SignatureError;
+use crate::signing::ConsensusSchemeError;
 
 /// Enumerates everything that can go wrong during consensus operations.
 #[derive(Debug, thiserror::Error)]
@@ -48,8 +48,6 @@ pub enum ConsensusError {
     InvalidVoteTimestamp,
     #[error("Vote timestamp is older than creation time")]
     TimestampOlderThanCreationTime,
-    #[error("Mismatched length: expected {expect}, actual {actual}")]
-    MismatchedLength { expect: usize, actual: usize },
 
     // Session/State Errors
     #[error("Session not active")]
@@ -71,10 +69,8 @@ pub enum ConsensusError {
     #[error("Consensus failed")]
     ConsensusFailed,
 
-    #[error("Invalid signature: {0}")]
-    InvalidSignature(#[from] SignatureError),
-    #[error("Failed to sign message: {0}")]
-    FailedToSignMessage(#[from] alloy_signer::Error),
+    #[error("Signature scheme failure: {0}")]
+    SignatureScheme(#[from] ConsensusSchemeError),
     #[error("Failed to get current time")]
     FailedToGetCurrentTime(#[from] std::time::SystemTimeError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! use hashgraph_like_consensus::{
 //!     scope::ScopeID,
 //!     service::DefaultConsensusService,
+//!     signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
 //!     types::CreateProposalRequest,
 //! };
 //! use alloy::signers::local::PrivateKeySigner;
@@ -62,7 +63,7 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let service = DefaultConsensusService::default();
 //! let scope = ScopeID::from("my-scope");
-//! let signer = PrivateKeySigner::random();
+//! let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
 //!
 //! let proposal = service
 //!     .create_proposal(
@@ -70,7 +71,7 @@
 //!         CreateProposalRequest::new(
 //!             "Upgrade contract".into(),
 //!             b"Switch to v2".to_vec(),
-//!             signer.address().as_slice().to_vec(),
+//!             signer.identity().to_vec(),
 //!             3,    // expected voters
 //!             60,   // expiration (seconds from now)
 //!             true, // liveness: silent peers count as YES at timeout
@@ -96,6 +97,7 @@
 //! | [`types`] | Request/event types ([`CreateProposalRequest`](types::CreateProposalRequest), [`ConsensusEvent`](types::ConsensusEvent)) |
 //! | [`storage`] | [`ConsensusStorage`](storage::ConsensusStorage) trait and [`InMemoryConsensusStorage`](storage::InMemoryConsensusStorage) |
 //! | [`events`] | [`ConsensusEventBus`](events::ConsensusEventBus) trait and [`BroadcastEventBus`](events::BroadcastEventBus) |
+//! | [`signing`] | [`ConsensusSignatureScheme`](signing::ConsensusSignatureScheme) trait and the default [`EthereumConsensusSigner`](signing::EthereumConsensusSigner) impl |
 //! | [`error`] | [`ConsensusError`](error::ConsensusError) enum |
 //! | [`utils`] | Low-level validation and hashing helpers |
 
@@ -114,6 +116,7 @@ pub mod scope_config;
 pub mod service;
 pub mod service_stats;
 pub mod session;
+pub mod signing;
 pub mod storage;
 pub mod types;
 pub mod utils;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use alloy_signer::Signer;
 use tokio::time::Duration;
 
 use crate::{
@@ -10,6 +9,7 @@ use crate::{
     scope::{ConsensusScope, ScopeID},
     scope_config::{NetworkType, ScopeConfig, ScopeConfigBuilder},
     session::{ConsensusConfig, ConsensusSession, ConsensusState},
+    signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
     storage::{ConsensusStorage, InMemoryConsensusStorage},
     types::{ConsensusEvent, CreateProposalRequest, SessionTransition},
     utils::{
@@ -21,23 +21,35 @@ use crate::{
 ///
 /// This is the main entry point for using the consensus service.
 /// It handles creating proposals, processing votes, and managing timeouts.
-pub struct ConsensusService<Scope, S, E>
+///
+/// Generic parameters:
+///
+/// - `Scope`: scope key type (see [`ConsensusScope`]).
+/// - `Storage`: storage backend (see [`ConsensusStorage`]).
+/// - `Event`: event bus backend (see [`ConsensusEventBus`]).
+/// - `Signer`: signature scheme (see [`ConsensusSignatureScheme`]). Carried only
+///   as a type; the service calls `Signer::verify` statically when validating
+///   incoming votes. All peers on a network must agree on this type.
+pub struct ConsensusService<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
-    storage: S,
+    storage: Storage,
     max_sessions_per_scope: usize,
-    event_bus: E,
+    event_bus: Event,
     _scope: PhantomData<Scope>,
+    _scheme: PhantomData<fn() -> Signer>,
 }
 
-impl<Scope, S, E> Clone for ConsensusService<Scope, S, E>
+impl<Scope, Storage, Event, Signer> Clone for ConsensusService<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
     fn clone(&self) -> Self {
         Self {
@@ -45,17 +57,21 @@ where
             max_sessions_per_scope: self.max_sessions_per_scope,
             event_bus: self.event_bus.clone(),
             _scope: PhantomData,
+            _scheme: PhantomData,
         }
     }
 }
 
-/// A ready-to-use service with in-memory storage and broadcast events.
-///
-/// This is the easiest way to get started. It stores everything in memory (great for
-/// testing or single-node setups) and uses a simple broadcast channel for events.
-/// If you need persistence or custom event handling, use `ConsensusService` directly.
-pub type DefaultConsensusService =
-    ConsensusService<ScopeID, InMemoryConsensusStorage<ScopeID>, BroadcastEventBus<ScopeID>>;
+/// A ready-to-use service with in-memory storage, broadcast events, and the
+/// [`EthereumConsensusSigner`] scheme. Intended for tests and single-node
+/// integrations. Production deployments typically construct
+/// [`ConsensusService`] directly with their own scheme.
+pub type DefaultConsensusService = ConsensusService<
+    ScopeID,
+    InMemoryConsensusStorage<ScopeID>,
+    BroadcastEventBus<ScopeID>,
+    EthereumConsensusSigner,
+>;
 
 impl DefaultConsensusService {
     /// Create a service with default settings (10 max sessions per scope).
@@ -83,23 +99,32 @@ impl Default for DefaultConsensusService {
     }
 }
 
-impl<Scope, S, E> ConsensusService<Scope, S, E>
+impl<Scope, Storage, Event, Signer> ConsensusService<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
     /// Build a service with your own storage and event bus implementations.
     ///
-    /// Use this when you need custom persistence (like a database) or event handling.
-    /// The `max_sessions_per_scope` parameter controls how many sessions can exist per scope.
-    /// When the limit is reached, older sessions are automatically removed.
-    pub fn new_with_components(storage: S, event_bus: E, max_sessions_per_scope: usize) -> Self {
+    /// The signature scheme `Signer` is selected via turbofish or type inference at
+    /// the call site (or by using a type alias like
+    /// [`DefaultConsensusService`]). Use this when you need custom persistence
+    /// (like a database) or event handling. The `max_sessions_per_scope`
+    /// parameter controls how many sessions can exist per scope. When the
+    /// limit is reached, older sessions are automatically removed.
+    pub fn new_with_components(
+        storage: Storage,
+        event_bus: Event,
+        max_sessions_per_scope: usize,
+    ) -> Self {
         Self {
             storage,
             max_sessions_per_scope,
             event_bus,
             _scope: PhantomData,
+            _scheme: PhantomData,
         }
     }
 
@@ -109,14 +134,14 @@ where
     ///
     /// Use this for reading state (sessions, proposals, scope config) and for
     /// lifecycle operations like [`delete_scope`](ConsensusStorage::delete_scope).
-    pub fn storage(&self) -> &S {
+    pub fn storage(&self) -> &Storage {
         &self.storage
     }
 
     /// Access the underlying event bus.
     ///
     /// Use this to [`subscribe`](ConsensusEventBus::subscribe) to consensus events.
-    pub fn event_bus(&self) -> &E {
+    pub fn event_bus(&self) -> &Event {
         &self.event_bus
     }
 
@@ -155,7 +180,8 @@ where
     ) -> Result<Proposal, ConsensusError> {
         let proposal = request.into_proposal()?;
         let config = self.resolve_config(scope, config, Some(&proposal)).await?;
-        let (session, _) = ConsensusSession::from_proposal(proposal.clone(), config.clone())?;
+        let (session, _) =
+            ConsensusSession::from_proposal::<Signer>(proposal.clone(), config.clone())?;
         self.save_session(scope, session).await?;
         self.trim_scope_sessions(scope).await?;
         Ok(proposal)
@@ -166,18 +192,21 @@ where
     /// The vote is cryptographically signed with `signer` and linked into the
     /// hashgraph chain. Returns the signed [`Vote`] for network propagation.
     /// Each voter can only vote once per proposal.
-    pub async fn cast_vote<SN: Signer + Sync + Send>(
+    ///
+    /// The signer is of the same scheme `Signer` that the service uses for
+    /// verification, so signatures it produces are guaranteed to round-trip
+    /// through [`process_incoming_vote`](Self::process_incoming_vote).
+    pub async fn cast_vote(
         &self,
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
-        signer: SN,
+        signer: Signer,
     ) -> Result<Vote, ConsensusError> {
         let session = self.get_session(scope, proposal_id).await?;
         validate_proposal_timestamp(session.proposal.expiration_timestamp)?;
 
-        let voter_address = signer.address().as_slice().to_vec();
-        if session.votes.contains_key(&voter_address) {
+        if session.votes.contains_key(signer.identity()) {
             return Err(ConsensusError::UserAlreadyVoted);
         }
 
@@ -196,12 +225,12 @@ where
     ///
     /// Convenience method useful for the proposal creator who wants to immediately
     /// gossip the updated proposal to peers.
-    pub async fn cast_vote_and_get_proposal<SN: Signer + Sync + Send>(
+    pub async fn cast_vote_and_get_proposal(
         &self,
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
-        signer: SN,
+        signer: Signer,
     ) -> Result<Proposal, ConsensusError> {
         self.cast_vote(scope, proposal_id, choice, signer).await?;
         let session = self.get_session(scope, proposal_id).await?;
@@ -225,7 +254,7 @@ where
             return Err(ConsensusError::ProposalAlreadyExist);
         }
         let config = self.resolve_config(scope, None, Some(&proposal)).await?;
-        let (session, transition) = ConsensusSession::from_proposal(proposal, config)?;
+        let (session, transition) = ConsensusSession::from_proposal::<Signer>(proposal, config)?;
         self.handle_transition(scope, session.proposal.proposal_id, transition);
         self.save_session(scope, session).await?;
         self.trim_scope_sessions(scope).await?;
@@ -243,7 +272,7 @@ where
         vote: Vote,
     ) -> Result<(), ConsensusError> {
         let session = self.get_session(scope, vote.proposal_id).await?;
-        validate_vote(
+        validate_vote::<Signer>(
             &vote,
             session.proposal.expiration_timestamp,
             session.proposal.timestamp,
@@ -361,7 +390,7 @@ where
     pub async fn scope(
         &self,
         scope: &Scope,
-    ) -> Result<ScopeConfigBuilderWrapper<Scope, S, E>, ConsensusError> {
+    ) -> Result<ScopeConfigBuilderWrapper<Scope, Storage, Event, Signer>, ConsensusError> {
         let existing_config = self.storage.get_scope_config(scope).await?;
         let builder = if let Some(config) = existing_config {
             ScopeConfigBuilder::from_existing(config)
@@ -514,25 +543,27 @@ where
 }
 
 /// Wrapper around ScopeConfigBuilder that stores service and scope for convenience methods.
-pub struct ScopeConfigBuilderWrapper<Scope, S, E>
+pub struct ScopeConfigBuilderWrapper<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
-    service: ConsensusService<Scope, S, E>,
+    service: ConsensusService<Scope, Storage, Event, Signer>,
     scope: Scope,
     builder: ScopeConfigBuilder,
 }
 
-impl<Scope, S, E> ScopeConfigBuilderWrapper<Scope, S, E>
+impl<Scope, Storage, Event, Signer> ScopeConfigBuilderWrapper<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
     fn new(
-        service: ConsensusService<Scope, S, E>,
+        service: ConsensusService<Scope, Storage, Event, Signer>,
         scope: Scope,
         builder: ScopeConfigBuilder,
     ) -> Self {

--- a/src/service_stats.rs
+++ b/src/service_stats.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     events::ConsensusEventBus, scope::ConsensusScope, service::ConsensusService,
-    session::ConsensusState, storage::ConsensusStorage,
+    session::ConsensusState, signing::ConsensusSignatureScheme, storage::ConsensusStorage,
 };
 
 /// Aggregate counters for all sessions within a single scope.
@@ -18,11 +18,12 @@ pub struct ConsensusStats {
     pub consensus_reached: usize,
 }
 
-impl<Scope, S, E> ConsensusService<Scope, S, E>
+impl<Scope, Storage, Event, Signer> ConsensusService<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
-    S: ConsensusStorage<Scope>,
-    E: ConsensusEventBus<Scope>,
+    Storage: ConsensusStorage<Scope>,
+    Event: ConsensusEventBus<Scope>,
+    Signer: ConsensusSignatureScheme,
 {
     /// Get statistics about proposals in a scope.
     ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,6 +10,7 @@ use crate::{
     error::ConsensusError,
     protos::consensus::v1::{Proposal, Vote},
     scope_config::{NetworkType, ScopeConfig},
+    signing::ConsensusSignatureScheme,
     types::SessionTransition,
     utils::{
         calculate_consensus_result, calculate_max_rounds, current_timestamp, validate_proposal,
@@ -193,11 +194,11 @@ impl ConsensusSession {
     /// Create a session from a proposal, validating the proposal and all votes.
     /// This validates the proposal structure, vote chain, and individual votes before creating the session.
     /// The session is created with votes already processed and rounds correctly set.
-    pub fn from_proposal(
+    pub fn from_proposal<Signer: ConsensusSignatureScheme>(
         proposal: Proposal,
         config: ConsensusConfig,
     ) -> Result<(Self, SessionTransition), ConsensusError> {
-        validate_proposal(&proposal)?;
+        validate_proposal::<Signer>(&proposal)?;
 
         // Create clean proposal for session (votes will be added via initialize_with_votes)
         let existing_votes = proposal.votes.clone();
@@ -207,7 +208,7 @@ impl ConsensusSession {
         clean_proposal.round = 1;
 
         let mut session = Self::new(clean_proposal, config);
-        let transition = session.initialize_with_votes(
+        let transition = session.initialize_with_votes::<Signer>(
             existing_votes,
             proposal.expiration_timestamp,
             proposal.timestamp,
@@ -241,7 +242,7 @@ impl ConsensusSession {
 
     /// Initialize session with multiple votes, validating all before adding any.
     /// Validates duplicates, vote chain, and individual votes, then adds all atomically.
-    pub(crate) fn initialize_with_votes(
+    pub(crate) fn initialize_with_votes<Signer: ConsensusSignatureScheme>(
         &mut self,
         votes: Vec<Vote>,
         expiration_timestamp: u64,
@@ -273,7 +274,7 @@ impl ConsensusSession {
 
         validate_vote_chain(&votes)?;
         for vote in &votes {
-            validate_vote(vote, expiration_timestamp, creation_time)?;
+            validate_vote::<Signer>(vote, expiration_timestamp, creation_time)?;
         }
 
         self.check_round_limit(votes.len())?;
@@ -403,9 +404,14 @@ mod tests {
     use crate::{
         error::ConsensusError,
         session::{ConsensusConfig, ConsensusSession, ConsensusState},
+        signing::EthereumConsensusSigner,
         types::CreateProposalRequest,
         utils::build_vote,
     };
+
+    fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+        EthereumConsensusSigner::new(signer)
+    }
 
     #[tokio::test]
     async fn enforce_max_rounds_gossipsub() {
@@ -431,22 +437,30 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote)
-        let vote1 = build_vote(&session.proposal, true, signer1).await.unwrap();
+        let vote1 = build_vote(&session.proposal, true, wrap(signer1))
+            .await
+            .unwrap();
         session.add_vote(vote1).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (second vote)
-        let vote2 = build_vote(&session.proposal, false, signer2).await.unwrap();
+        let vote2 = build_vote(&session.proposal, false, wrap(signer2))
+            .await
+            .unwrap();
         session.add_vote(vote2).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (third vote)
-        let vote3 = build_vote(&session.proposal, true, signer3).await.unwrap();
+        let vote3 = build_vote(&session.proposal, true, wrap(signer3))
+            .await
+            .unwrap();
         session.add_vote(vote3).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (fourth vote) - should succeed
-        let vote4 = build_vote(&session.proposal, true, signer4).await.unwrap();
+        let vote4 = build_vote(&session.proposal, true, wrap(signer4))
+            .await
+            .unwrap();
         session.add_vote(vote4).unwrap();
         assert_eq!(session.proposal.round, 2);
         assert_eq!(session.votes.len(), 4);
@@ -478,31 +492,41 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote, 1 vote total)
-        let vote1 = build_vote(&session.proposal, true, signer1).await.unwrap();
+        let vote1 = build_vote(&session.proposal, true, wrap(signer1))
+            .await
+            .unwrap();
         session.add_vote(vote1).unwrap();
         assert_eq!(session.proposal.round, 2);
         assert_eq!(session.votes.len(), 1);
 
         // Round 2 -> Round 3 (second vote, 2 votes total) - should succeed
-        let vote2 = build_vote(&session.proposal, false, signer2).await.unwrap();
+        let vote2 = build_vote(&session.proposal, false, wrap(signer2))
+            .await
+            .unwrap();
         session.add_vote(vote2).unwrap();
         assert_eq!(session.proposal.round, 3);
         assert_eq!(session.votes.len(), 2);
 
         // Round 3 -> Round 4 (third vote, 3 votes total) - should succeed
-        let vote3 = build_vote(&session.proposal, true, signer3).await.unwrap();
+        let vote3 = build_vote(&session.proposal, true, wrap(signer3))
+            .await
+            .unwrap();
         session.add_vote(vote3).unwrap();
         assert_eq!(session.proposal.round, 4);
         assert_eq!(session.votes.len(), 3);
 
         // Round 4 -> Round 5 (fourth vote, 4 votes total) - should succeed (dynamic limit = 4)
-        let vote4 = build_vote(&session.proposal, true, signer4).await.unwrap();
+        let vote4 = build_vote(&session.proposal, true, wrap(signer4))
+            .await
+            .unwrap();
         session.add_vote(vote4).unwrap();
         assert_eq!(session.proposal.round, 5);
         assert_eq!(session.votes.len(), 4);
 
         // Fifth vote would exceed dynamic max_round_limit (=4 votes)
-        let vote5 = build_vote(&session.proposal, true, signer5).await.unwrap();
+        let vote5 = build_vote(&session.proposal, true, wrap(signer5))
+            .await
+            .unwrap();
         let err = session.add_vote(vote5).unwrap_err();
         assert!(matches!(err, ConsensusError::MaxRoundsExceeded));
     }
@@ -553,7 +577,7 @@ mod tests {
         let mut failed_session =
             ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
         failed_session.state = ConsensusState::Failed;
-        let vote = build_vote(&failed_session.proposal, true, signer.clone())
+        let vote = build_vote(&failed_session.proposal, true, wrap(signer.clone()))
             .await
             .unwrap();
         let err = failed_session.add_vote(vote).unwrap_err();
@@ -562,7 +586,7 @@ mod tests {
         // Finalized sessions return existing transition/result.
         let mut finalized_session = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
         finalized_session.state = ConsensusState::ConsensusReached(true);
-        let vote = build_vote(&finalized_session.proposal, true, signer)
+        let vote = build_vote(&finalized_session.proposal, true, wrap(signer))
             .await
             .unwrap();
         let transition = finalized_session.add_vote(vote).unwrap();
@@ -590,20 +614,24 @@ mod tests {
         let mut inactive = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
         inactive.state = ConsensusState::Failed;
         let err = inactive
-            .initialize_with_votes(vec![], proposal.expiration_timestamp, proposal.timestamp)
+            .initialize_with_votes::<EthereumConsensusSigner>(
+                vec![],
+                proposal.expiration_timestamp,
+                proposal.timestamp,
+            )
             .unwrap_err();
         assert!(matches!(err, ConsensusError::SessionNotActive));
 
         // Duplicate owners are rejected before chain/signature checks.
         let mut dup_session = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
-        let vote1 = build_vote(&dup_session.proposal, true, signer.clone())
+        let vote1 = build_vote(&dup_session.proposal, true, wrap(signer.clone()))
             .await
             .unwrap();
-        let vote2 = build_vote(&dup_session.proposal, false, signer)
+        let vote2 = build_vote(&dup_session.proposal, false, wrap(signer))
             .await
             .unwrap();
         let err = dup_session
-            .initialize_with_votes(
+            .initialize_with_votes::<EthereumConsensusSigner>(
                 vec![vote1, vote2],
                 proposal.expiration_timestamp,
                 proposal.timestamp,

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,0 +1,83 @@
+//! Pluggable signature scheme for vote authentication.
+//!
+//! Each vote in the consensus protocol is authenticated by a signature over
+//! its canonical encoding. The crate is agnostic to the cryptographic scheme:
+//! embedders pick a concrete [`ConsensusSignatureScheme`] type that defines
+//! how peers sign and how the service verifies.
+//!
+//! The wire layer ([`Vote::vote_owner`] and [`Vote::signature`] in the
+//! protobuf) is byte-flexible; the scheme gives those bytes their meaning.
+//!
+//! [`ethereum::EthereumConsensusSigner`] provides a default ECDSA-secp256k1
+//! implementation matching the historical behavior of the crate. It is the
+//! scheme used by [`DefaultConsensusService`] but the core service is fully
+//! generic — pick a different scheme to integrate Ed25519, an HSM, or any
+//! other signing system.
+//!
+//! [`Vote::vote_owner`]: crate::protos::consensus::v1::Vote::vote_owner
+//! [`Vote::signature`]: crate::protos::consensus::v1::Vote::signature
+//! [`DefaultConsensusService`]: crate::service::DefaultConsensusService
+
+use std::future::Future;
+
+mod ethereum;
+pub use ethereum::EthereumConsensusSigner;
+
+/// A signature scheme that the consensus service uses to sign and verify votes.
+///
+/// Implementors play two roles:
+///
+/// - **As a signer instance**: a value carrying private state (key material,
+///   HSM handle, etc.) produces signatures via [`identity`](Self::identity)
+///   and [`sign`](Self::sign). One such instance exists per peer that needs
+///   to cast votes.
+/// - **As a scheme type**: the type itself is used by the service to verify
+///   incoming signatures via the static [`verify`](Self::verify) method.
+///   Verification needs no instance — only the public bytes from the wire.
+///
+/// All peers on a network must agree on the scheme, since they all verify
+/// each other's signatures using the same `verify` rule.
+pub trait ConsensusSignatureScheme: Send + Sync {
+    /// Stable identity bytes for this signer (e.g. address, public key, account id).
+    ///
+    /// Written into [`Vote::vote_owner`] when the signer casts a vote and
+    /// passed back into [`verify`](Self::verify) when the vote is checked.
+    ///
+    /// [`Vote::vote_owner`]: crate::protos::consensus::v1::Vote::vote_owner
+    fn identity(&self) -> &[u8];
+
+    /// Sign `payload` and return the raw signature bytes.
+    ///
+    /// Length and encoding are scheme-specific.
+    fn sign(
+        &self,
+        payload: &[u8],
+    ) -> impl Future<Output = Result<Vec<u8>, ConsensusSchemeError>> + Send;
+
+    /// Verify that `signature` over `payload` was produced by the holder of
+    /// `identity`.
+    ///
+    /// This is a free function on the scheme type — no instance needed. The
+    /// service calls it for every incoming vote.
+    ///
+    /// Returns `Ok(true)` when the signature is valid, `Ok(false)` when it is
+    /// well-formed but does not match, and `Err` when the inputs are malformed
+    /// (wrong signature length, bad encoding, etc.).
+    fn verify(
+        identity: &[u8],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<bool, ConsensusSchemeError>;
+}
+
+/// Error returned by [`ConsensusSignatureScheme`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ConsensusSchemeError {
+    /// The scheme could not produce a signature for the given payload.
+    #[error("Signing failed: {0}")]
+    Sign(String),
+    /// The scheme rejected the inputs (wrong signature length, unparseable
+    /// bytes, identity of unexpected shape, etc.).
+    #[error("Verification rejected inputs: {0}")]
+    Verify(String),
+}

--- a/src/signing/ethereum.rs
+++ b/src/signing/ethereum.rs
@@ -1,0 +1,99 @@
+//! Default ECDSA-secp256k1 signing scheme.
+//!
+use alloy::primitives::Address;
+use alloy::signers::local::PrivateKeySigner;
+use alloy_signer::{Signature, Signer};
+
+use super::{ConsensusSchemeError, ConsensusSignatureScheme};
+
+/// Length of an Ethereum recoverable ECDSA signature in bytes (r || s || v).
+const ETHEREUM_SIGNATURE_LENGTH: usize = 65;
+/// Length of an Ethereum address in bytes.
+const ETHEREUM_ADDRESS_LENGTH: usize = 20;
+
+/// ECDSA-secp256k1 scheme backed by an alloy [`PrivateKeySigner`].
+///
+/// As a signer instance, holds a 32-byte private key and produces 65-byte
+/// recoverable signatures over the secp256k1 curve. The signer's identity is
+/// its 20-byte Ethereum address.
+///
+/// As a scheme type, `EthereumConsensusSigner::verify` is a stateless
+/// signature check used by [`ConsensusService`](crate::service::ConsensusService)
+/// when this scheme is selected.
+#[derive(Debug, Clone)]
+pub struct EthereumConsensusSigner {
+    inner: PrivateKeySigner,
+    address_bytes: Vec<u8>,
+}
+
+impl EthereumConsensusSigner {
+    pub fn new(signer: PrivateKeySigner) -> Self {
+        let address_bytes = signer.address().as_slice().to_vec();
+        Self {
+            inner: signer,
+            address_bytes,
+        }
+    }
+
+    pub fn inner(&self) -> &PrivateKeySigner {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> PrivateKeySigner {
+        self.inner
+    }
+}
+
+impl From<PrivateKeySigner> for EthereumConsensusSigner {
+    fn from(signer: PrivateKeySigner) -> Self {
+        Self::new(signer)
+    }
+}
+
+impl ConsensusSignatureScheme for EthereumConsensusSigner {
+    fn identity(&self) -> &[u8] {
+        &self.address_bytes
+    }
+
+    async fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
+        let signature = self
+            .inner
+            .sign_message(payload)
+            .await
+            .map_err(|e| ConsensusSchemeError::Sign(e.to_string()))?;
+        Ok(signature.as_bytes().to_vec())
+    }
+
+    fn verify(
+        identity: &[u8],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<bool, ConsensusSchemeError> {
+        if signature.len() != ETHEREUM_SIGNATURE_LENGTH {
+            return Err(ConsensusSchemeError::Verify(format!(
+                "expected {ETHEREUM_SIGNATURE_LENGTH}-byte signature, got {}",
+                signature.len()
+            )));
+        }
+        if identity.len() != ETHEREUM_ADDRESS_LENGTH {
+            return Err(ConsensusSchemeError::Verify(format!(
+                "expected {ETHEREUM_ADDRESS_LENGTH}-byte address, got {}",
+                identity.len()
+            )));
+        }
+
+        let mut sig_bytes = [0u8; ETHEREUM_SIGNATURE_LENGTH];
+        sig_bytes.copy_from_slice(signature);
+        let signature = Signature::from_raw_array(&sig_bytes)
+            .map_err(|e| ConsensusSchemeError::Verify(e.to_string()))?;
+        let recovered = signature
+            .recover_address_from_msg(payload)
+            .map_err(|e| ConsensusSchemeError::Verify(e.to_string()))?;
+
+        let mut addr = [0u8; ETHEREUM_ADDRESS_LENGTH];
+        addr.copy_from_slice(identity);
+        let expected = Address::from(addr);
+
+        Ok(recovered == expected)
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,6 @@
 //! [`ConsensusService`](crate::service::ConsensusService) API calls these internally.
 //! They are public for advanced use cases or custom integrations.
 
-use alloy_signer::{Signature, Signer};
 use prost::Message;
 use sha2::{Digest, Sha256};
 use std::{
@@ -16,9 +15,8 @@ use uuid::Uuid;
 use crate::{
     error::ConsensusError,
     protos::consensus::v1::{Proposal, Vote},
+    signing::ConsensusSignatureScheme,
 };
-
-const SIGNATURE_LENGTH: usize = 65;
 
 /// Fold a 128-bit value into 32 bits via XOR so every bit contributes.
 fn fold_u128_to_u32(n: u128) -> u32 {
@@ -56,21 +54,21 @@ pub fn compute_vote_hash(vote: &Vote) -> Vec<u8> {
 /// This builds a vote that links to previous votes in the hashgraph structure.
 /// The vote is signed with the provided signer and includes all the necessary
 /// fields for validation (parent_hash, received_hash, vote_hash, signature).
-pub async fn build_vote<S: Signer + Sync>(
+pub async fn build_vote<Signer: ConsensusSignatureScheme>(
     proposal: &Proposal,
     user_vote: bool,
-    signer: S,
+    signer: Signer,
 ) -> Result<Vote, ConsensusError> {
     let now = current_timestamp()?;
 
-    let voter_address = signer.address().as_slice().to_vec();
+    let voter_identity = signer.identity();
     // RFC Section 2.2: Define `parent_hash` as hash of previous owner's vote (empty if none).
     // RFC Section 2.3: Set `received_hash` to hash of immediately previous vote (last vote in list).
     let (parent_hash, received_hash) = if let Some(latest_vote) = proposal.votes.last() {
         let own_last_vote = proposal
             .votes
             .iter()
-            .rfind(|v| v.vote_owner == voter_address);
+            .rfind(|v| v.vote_owner.as_slice() == voter_identity);
 
         if let Some(own_vote) = own_last_vote {
             (own_vote.vote_hash.clone(), latest_vote.vote_hash.clone())
@@ -85,7 +83,7 @@ pub async fn build_vote<S: Signer + Sync>(
 
     let mut vote = Vote {
         vote_id,
-        vote_owner: signer.address().as_slice().to_vec(),
+        vote_owner: voter_identity.to_vec(),
         proposal_id: proposal.proposal_id,
         timestamp: now,
         vote: user_vote,
@@ -97,58 +95,38 @@ pub async fn build_vote<S: Signer + Sync>(
 
     vote.vote_hash = compute_vote_hash(&vote);
     let vote_bytes = vote.encode_to_vec();
-    let signature = signer.sign_message(&vote_bytes).await?;
-    vote.signature = signature.as_bytes().to_vec();
+    let signature = signer.sign(&vote_bytes).await?;
+    vote.signature = signature;
     Ok(vote)
 }
 
-/// Verify that a vote's signature is valid and matches the vote owner.
-///
-/// Checks that the signature was created by the owner's private key and that
-/// it signs the correct vote data. Returns `true` if valid, `false` otherwise.
-fn verify_vote_hash(
-    signature: &[u8],
-    public_key: &[u8],
-    message: &[u8],
-) -> Result<bool, ConsensusError> {
-    let signature_bytes: [u8; SIGNATURE_LENGTH] =
-        signature
-            .try_into()
-            .map_err(|_| ConsensusError::MismatchedLength {
-                expect: SIGNATURE_LENGTH,
-                actual: signature.len(),
-            })?;
-    let signature = Signature::from_raw_array(&signature_bytes)?;
-    let address = signature.recover_address_from_msg(message)?;
-    let address_bytes = address.as_slice().to_vec();
-    Ok(address_bytes == public_key)
-}
-
-/// Validate a proposal and all its votes.
+/// Validate a proposal and all its votes against a signature scheme.
 ///
 /// Checks that the proposal hasn't expired.
 /// Also validates that all votes belong to this proposal, vote signatures are valid,
 /// and the vote chain (parent_hash/received_hash) is correct.
 /// Should be called when receiving a proposal from the network.
-pub fn validate_proposal(proposal: &Proposal) -> Result<(), ConsensusError> {
+pub fn validate_proposal<Signer: ConsensusSignatureScheme>(
+    proposal: &Proposal,
+) -> Result<(), ConsensusError> {
     validate_proposal_timestamp(proposal.expiration_timestamp)?;
 
     for vote in proposal.votes.iter() {
         if vote.proposal_id != proposal.proposal_id {
             return Err(ConsensusError::VoteProposalIdMismatch);
         }
-        validate_vote(vote, proposal.expiration_timestamp, proposal.timestamp)?;
+        validate_vote::<Signer>(vote, proposal.expiration_timestamp, proposal.timestamp)?;
     }
     validate_vote_chain(&proposal.votes)?;
     Ok(())
 }
 
-/// Validate a single vote.
+/// Validate a single vote against a signature scheme.
 ///
 /// RFC Section 3.4: Validates timestamps (reject future timestamps and votes older than 1 hour).
 /// Also checks that the vote hash is correct, the signature is valid, and the vote hasn't expired.
 /// This prevents replay attacks and ensures vote integrity.
-pub(crate) fn validate_vote(
+pub(crate) fn validate_vote<Signer: ConsensusSignatureScheme>(
     vote: &Vote,
     expiration_timestamp: u64,
     creation_time: u64,
@@ -165,13 +143,6 @@ pub(crate) fn validate_vote(
         return Err(ConsensusError::EmptySignature);
     }
 
-    if vote.signature.len() != SIGNATURE_LENGTH {
-        return Err(ConsensusError::MismatchedLength {
-            expect: SIGNATURE_LENGTH,
-            actual: vote.signature.len(),
-        });
-    }
-
     let expected_hash = compute_vote_hash(vote);
     if vote.vote_hash != expected_hash {
         return Err(ConsensusError::InvalidVoteHash);
@@ -181,7 +152,7 @@ pub(crate) fn validate_vote(
     vote_copy.signature = Vec::new();
     let vote_copy_bytes = vote_copy.encode_to_vec();
 
-    let verified = verify_vote_hash(&vote.signature, &vote.vote_owner, &vote_copy_bytes)?;
+    let verified = Signer::verify(&vote.vote_owner, &vote_copy_bytes, &vote.signature)?;
 
     if !verified {
         return Err(ConsensusError::InvalidVoteSignature);

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -3,10 +3,15 @@ use futures::future::join_all;
 use std::{sync::Arc, time::Duration};
 use tokio::{spawn, sync::Barrier, time::sleep};
 
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use hashgraph_like_consensus::{
     error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
     session::ConsensusConfig, storage::ConsensusStorage, types::CreateProposalRequest,
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE: &str = "concurrency_scope";
 const PROPOSAL_NAME: &str = "Concurrency Test";
@@ -63,7 +68,7 @@ async fn test_concurrent_vote_casting() {
             barrier_clone.wait().await;
             let voter = PrivateKeySigner::random();
             service_clone
-                .cast_vote(&scope_clone, proposal_id, i % 2 == 0, voter)
+                .cast_vote(&scope_clone, proposal_id, i % 2 == 0, wrap(voter))
                 .await
         });
         handles.push(handle);
@@ -161,7 +166,7 @@ async fn test_concurrent_duplicate_vote_rejection() {
         let voter_clone = voter.clone();
         let handle = spawn(async move {
             service_clone
-                .cast_vote(&scope_clone, proposal_id, true, voter_clone)
+                .cast_vote(&scope_clone, proposal_id, true, wrap(voter_clone))
                 .await
         });
         handles.push(handle);

--- a/tests/consensus_service_tests.rs
+++ b/tests/consensus_service_tests.rs
@@ -1,5 +1,6 @@
 use alloy::signers::Signer;
 use alloy::signers::local::PrivateKeySigner;
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use prost::Message;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -15,6 +16,10 @@ use hashgraph_like_consensus::{
     types::{ConsensusEvent, CreateProposalRequest},
     utils::{build_vote, compute_vote_hash},
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE1_NAME: &str = "scope1";
 const SCOPE2_NAME: &str = "scope2";
@@ -68,7 +73,7 @@ async fn cast_vote_or_panic(
     msg: &str,
 ) {
     service
-        .cast_vote(scope, proposal_id, choice, signer)
+        .cast_vote(scope, proposal_id, choice, wrap(signer))
         .await
         .expect(msg);
 }
@@ -97,7 +102,7 @@ async fn test_basic_consensus_flow() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote should succeed");
 
@@ -124,13 +129,13 @@ async fn test_basic_consensus_flow() {
 
     let voter_two = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter_two)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter_two))
         .await
         .expect("second vote should succeed");
 
     let voter_three = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter_three)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter_three))
         .await
         .expect("third vote should succeed");
 
@@ -172,7 +177,7 @@ async fn test_multi_scope_isolation() {
         .expect("scope1 proposal");
 
     service
-        .cast_vote_and_get_proposal(&scope1, proposal_1.proposal_id, VOTE_YES, signer1)
+        .cast_vote_and_get_proposal(&scope1, proposal_1.proposal_id, VOTE_YES, wrap(signer1))
         .await
         .expect("scope1 proposal_owner vote");
 
@@ -194,7 +199,7 @@ async fn test_multi_scope_isolation() {
         .expect("scope2 proposal");
 
     service
-        .cast_vote_and_get_proposal(&scope2, proposal_2.proposal_id, VOTE_YES, signer2)
+        .cast_vote_and_get_proposal(&scope2, proposal_2.proposal_id, VOTE_YES, wrap(signer2))
         .await
         .expect("scope2 proposal_owner vote");
 
@@ -249,14 +254,14 @@ async fn test_consensus_threshold_emits_event() {
         .expect("proposal should be created");
 
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote");
 
     for _ in 0..3 {
         let signer = PrivateKeySigner::random();
         service
-            .cast_vote(&scope, proposal.proposal_id, VOTE_YES, signer)
+            .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(signer))
             .await
             .expect("additional vote");
     }
@@ -909,13 +914,13 @@ async fn test_cast_vote_rejects_same_voter_twice() {
             &scope,
             proposal.proposal_id,
             VOTE_YES,
-            proposal_owner.clone(),
+            wrap(proposal_owner.clone()),
         )
         .await
         .expect("first vote should succeed");
 
     let err = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect_err("second vote from same voter should fail");
 
@@ -985,7 +990,12 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
     let unknown_proposal_id = proposal.proposal_id.wrapping_add(1);
     let vote_owner = PrivateKeySigner::random();
     let vote = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, vote_owner.clone())
+        .cast_vote(
+            &scope,
+            proposal.proposal_id,
+            VOTE_YES,
+            wrap(vote_owner.clone()),
+        )
         .await
         .expect("valid signed vote");
 
@@ -1082,12 +1092,12 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, voter)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
         .await
         .expect("valid vote should be built");
     vote.vote_hash = vec![1; 32];
@@ -1131,13 +1141,13 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
             &scope,
             proposal.proposal_id,
             VOTE_YES,
-            proposal_owner.clone(),
+            wrap(proposal_owner.clone()),
         )
         .await
         .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, voter)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
         .await
         .expect("valid vote should be built");
     let wrong_signer = PrivateKeySigner::random();
@@ -1187,12 +1197,12 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
             &scope,
             proposal.proposal_id,
             VOTE_YES,
-            proposal_owner.clone(),
+            wrap(proposal_owner.clone()),
         )
         .await
         .expect("first owner vote should succeed");
 
-    let duplicate_vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+    let duplicate_vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("duplicate vote should be signable");
 
@@ -1231,12 +1241,12 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, voter.clone())
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
         .await
         .expect("valid vote should be built");
     vote.timestamp = proposal.expiration_timestamp.saturating_add(1);
@@ -1286,13 +1296,13 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
         .expect("proposal should be created");
 
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote should succeed");
 
     let voter2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter2)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote should succeed");
 
@@ -1356,7 +1366,7 @@ async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
 
     // One vote is insufficient for n=4; transition should remain StillActive.
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should succeed");
 
@@ -1443,7 +1453,7 @@ async fn test_get_reached_proposals_with_consensus() {
 
     // Cast vote to reach consensus
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should succeed");
 
@@ -1536,7 +1546,7 @@ async fn test_get_reached_proposals_mixed_states() {
         .expect("proposal should be created");
 
     service
-        .cast_vote(&scope, proposal1.proposal_id, true, proposal_owner1)
+        .cast_vote(&scope, proposal1.proposal_id, true, wrap(proposal_owner1))
         .await
         .expect("vote should succeed");
 
@@ -1559,7 +1569,7 @@ async fn test_get_reached_proposals_mixed_states() {
         .expect("proposal should be created");
 
     service
-        .cast_vote(&scope, proposal2.proposal_id, false, proposal_owner2)
+        .cast_vote(&scope, proposal2.proposal_id, false, wrap(proposal_owner2))
         .await
         .expect("vote should succeed");
 
@@ -1689,7 +1699,7 @@ async fn test_delete_scope_cleans_up_all_state() {
     .await;
 
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should succeed");
 
@@ -1762,7 +1772,7 @@ async fn test_delete_scope_cleans_up_all_state() {
     .await;
 
     service
-        .cast_vote(&scope, new_proposal.proposal_id, VOTE_YES, new_owner)
+        .cast_vote(&scope, new_proposal.proposal_id, VOTE_YES, wrap(new_owner))
         .await
         .expect("vote on new proposal should succeed");
 

--- a/tests/custom_scheme_tests.rs
+++ b/tests/custom_scheme_tests.rs
@@ -1,0 +1,178 @@
+//! End-to-end test that exercises [`ConsensusService`] with a non-Ethereum
+//! signature scheme. Proves the [`ConsensusSignatureScheme`] abstraction
+//! holds for embedders integrating Ed25519, HSMs, libchat accounts, etc.
+//!
+//! The stub scheme used here is intentionally trivial — signatures are
+//! `SHA256(identity || payload)` — which is enough to demonstrate that votes
+//! signed by one peer and validated by another round-trip cleanly through the
+//! service without any Ethereum-specific assumptions.
+
+use hashgraph_like_consensus::{
+    events::BroadcastEventBus,
+    scope::ScopeID,
+    service::ConsensusService,
+    session::ConsensusConfig,
+    signing::{ConsensusSchemeError, ConsensusSignatureScheme},
+    storage::{ConsensusStorage, InMemoryConsensusStorage},
+    types::CreateProposalRequest,
+};
+use sha2::{Digest, Sha256};
+
+const STUB_IDENTITY_LEN: usize = 8;
+
+/// Trivial signature scheme used to validate the generic plumbing.
+///
+/// **Not cryptographically secure** — any holder of the identity can forge
+/// signatures. Only suitable as a test stub for verifying that
+/// [`ConsensusService`] does not bake in Ethereum-specific assumptions.
+#[derive(Debug, Clone)]
+struct StubSigner {
+    identity: [u8; STUB_IDENTITY_LEN],
+}
+
+impl StubSigner {
+    fn new(identity: [u8; STUB_IDENTITY_LEN]) -> Self {
+        Self { identity }
+    }
+
+    fn expected_signature(identity: &[u8], payload: &[u8]) -> Vec<u8> {
+        let mut h = Sha256::new();
+        h.update(identity);
+        h.update(payload);
+        h.finalize().to_vec()
+    }
+}
+
+impl ConsensusSignatureScheme for StubSigner {
+    fn identity(&self) -> &[u8] {
+        &self.identity
+    }
+
+    async fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
+        Ok(Self::expected_signature(&self.identity, payload))
+    }
+
+    fn verify(
+        identity: &[u8],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<bool, ConsensusSchemeError> {
+        if identity.len() != STUB_IDENTITY_LEN {
+            return Err(ConsensusSchemeError::Verify(format!(
+                "stub identity must be {STUB_IDENTITY_LEN} bytes, got {}",
+                identity.len()
+            )));
+        }
+        Ok(signature == Self::expected_signature(identity, payload))
+    }
+}
+
+type StubService = ConsensusService<
+    ScopeID,
+    InMemoryConsensusStorage<ScopeID>,
+    BroadcastEventBus<ScopeID>,
+    StubSigner,
+>;
+
+#[tokio::test]
+async fn stub_scheme_reaches_consensus_without_ethereum_types() {
+    let service: StubService = StubService::new_with_components(
+        InMemoryConsensusStorage::new(),
+        BroadcastEventBus::default(),
+        10,
+    );
+    let scope = ScopeID::from("stub-scope");
+
+    let owner = StubSigner::new([1; STUB_IDENTITY_LEN]);
+    let voter_two = StubSigner::new([2; STUB_IDENTITY_LEN]);
+    let voter_three = StubSigner::new([3; STUB_IDENTITY_LEN]);
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                "stub-proposal".into(),
+                b"payload".to_vec(),
+                owner.identity().to_vec(),
+                3,
+                60,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal should be created");
+
+    service
+        .cast_vote(&scope, proposal.proposal_id, true, owner)
+        .await
+        .expect("owner vote");
+    service
+        .cast_vote(&scope, proposal.proposal_id, true, voter_two)
+        .await
+        .expect("voter two");
+    service
+        .cast_vote(&scope, proposal.proposal_id, true, voter_three)
+        .await
+        .expect("voter three");
+
+    let session = service
+        .storage()
+        .get_session(&scope, proposal.proposal_id)
+        .await
+        .expect("get session")
+        .expect("session exists");
+    assert!(
+        session.get_consensus_result().expect("consensus reached"),
+        "3 YES votes via stub scheme should reach consensus"
+    );
+}
+
+#[tokio::test]
+async fn stub_scheme_rejects_forged_signature() {
+    let service: StubService = StubService::new_with_components(
+        InMemoryConsensusStorage::new(),
+        BroadcastEventBus::default(),
+        10,
+    );
+    let scope = ScopeID::from("stub-scope-forge");
+
+    let owner = StubSigner::new([9; STUB_IDENTITY_LEN]);
+    let voter = StubSigner::new([10; STUB_IDENTITY_LEN]);
+
+    let proposal = service
+        .create_proposal_with_config(
+            &scope,
+            CreateProposalRequest::new(
+                "stub-proposal".into(),
+                b"payload".to_vec(),
+                owner.identity().to_vec(),
+                2,
+                60,
+                true,
+            )
+            .expect("valid proposal request"),
+            Some(ConsensusConfig::gossipsub()),
+        )
+        .await
+        .expect("proposal should be created");
+
+    let mut vote = hashgraph_like_consensus::utils::build_vote(&proposal, true, voter.clone())
+        .await
+        .expect("vote");
+    // Tamper with the signature so verify() returns false.
+    vote.signature.iter_mut().for_each(|b| *b ^= 0xFF);
+
+    let err = service
+        .process_incoming_vote(&scope, vote)
+        .await
+        .expect_err("forged signature must be rejected");
+    assert!(
+        matches!(
+            err,
+            hashgraph_like_consensus::error::ConsensusError::InvalidVoteSignature
+        ),
+        "expected InvalidVoteSignature, got {err:?}"
+    );
+}

--- a/tests/network_gossip_tests.rs
+++ b/tests/network_gossip_tests.rs
@@ -3,8 +3,13 @@ use tokio::time::{Duration, sleep};
 
 use hashgraph_like_consensus::{
     error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
-    session::ConsensusConfig, storage::ConsensusStorage, types::CreateProposalRequest,
+    session::ConsensusConfig, signing::EthereumConsensusSigner, storage::ConsensusStorage,
+    types::CreateProposalRequest,
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE: &str = "network_gossip_scope";
 const PROPOSAL_NAME: &str = "Network Gossip Proposal";
@@ -49,7 +54,7 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
 
     // Peer A votes YES, gossip vote to peer B.
     let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, owner_a)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
         .await
         .expect("peer_a vote");
     peer_b
@@ -60,7 +65,7 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
     // Peer B votes YES, gossip vote to peer A.
     let owner_b = PrivateKeySigner::random();
     let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, owner_b)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_b))
         .await
         .expect("peer_b vote");
     peer_a
@@ -123,12 +128,12 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
 
     // Two YES votes are sufficient for n=3 with threshold 2/3 and majority YES.
     let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, owner_a)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
         .await
         .expect("peer_a vote");
     let owner_b = PrivateKeySigner::random();
     let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, owner_b)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_b))
         .await
         .expect("peer_b vote");
 
@@ -215,7 +220,7 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
 
     // 2 YES votes total.
     let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, owner_a)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
         .await
         .expect("peer_a vote");
     peer_b
@@ -228,7 +233,7 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
         .expect("peer_c accepts vote_a");
 
     let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, voter_b)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(voter_b))
         .await
         .expect("peer_b vote");
     peer_a
@@ -338,7 +343,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     // Cast votes sequentially, gossiping each vote to all peers before the next voter votes,
     // so that received_hash references match on every peer.
     let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, owner_a)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
         .await
         .expect("vote_a");
     for peer in [&peer_b, &peer_c, &peer_d] {
@@ -349,7 +354,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
 
     let voter_b = PrivateKeySigner::random();
     let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, voter_b)
+        .cast_vote(&scope, proposal.proposal_id, true, wrap(voter_b))
         .await
         .expect("vote_b");
     for peer in [&peer_a, &peer_c, &peer_d] {
@@ -360,7 +365,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
 
     let voter_c = PrivateKeySigner::random();
     let vote_c = peer_c
-        .cast_vote(&scope, proposal.proposal_id, false, voter_c)
+        .cast_vote(&scope, proposal.proposal_id, false, wrap(voter_c))
         .await
         .expect("vote_c");
     for peer in [&peer_a, &peer_b, &peer_d] {
@@ -371,7 +376,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
 
     let voter_d = PrivateKeySigner::random();
     let vote_d = peer_d
-        .cast_vote(&scope, proposal.proposal_id, false, voter_d)
+        .cast_vote(&scope, proposal.proposal_id, false, wrap(voter_d))
         .await
         .expect("vote_d");
     for peer in [&peer_a, &peer_b, &peer_c] {

--- a/tests/rfc_compliance_tests.rs
+++ b/tests/rfc_compliance_tests.rs
@@ -1,4 +1,5 @@
 use alloy::signers::{Signer, local::PrivateKeySigner};
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use prost::Message;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
@@ -12,6 +13,10 @@ use hashgraph_like_consensus::{
     types::CreateProposalRequest,
     utils::{build_vote, compute_vote_hash},
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE: &str = "rfc_compliance_scope";
 const PROPOSAL_NAME: &str = "RFC Compliance Test";
@@ -92,7 +97,7 @@ async fn test_round_increments_on_vote_p2p() {
     );
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should be added");
 
@@ -103,7 +108,7 @@ async fn test_round_increments_on_vote_p2p() {
 
     let voter2 = PrivateKeySigner::random();
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, voter2)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote should be added");
 
@@ -146,7 +151,7 @@ async fn test_gossipsub_rounds_stay_at_two() {
 
     // First vote moves to round 2
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should be added");
 
@@ -159,7 +164,7 @@ async fn test_gossipsub_rounds_stay_at_two() {
     // Second vote stays at round 2
     let voter2 = PrivateKeySigner::random();
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, voter2)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote should be added");
 
@@ -172,7 +177,7 @@ async fn test_gossipsub_rounds_stay_at_two() {
     // Third vote also stays at round 2 (this reaches consensus with 3 YES votes)
     let voter3 = PrivateKeySigner::random();
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, voter3)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter3))
         .await
         .expect("third vote should be added");
 
@@ -217,7 +222,7 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
 
     // First vote moves to round 2
     let mut last_proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should be added");
     assert_eq!(last_proposal.round, 2);
@@ -228,7 +233,7 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
     for i in 0..6 {
         let voter = PrivateKeySigner::random();
         last_proposal = service
-            .cast_vote_and_get_proposal(&scope, last_proposal.proposal_id, VOTE_YES, voter)
+            .cast_vote_and_get_proposal(&scope, last_proposal.proposal_id, VOTE_YES, wrap(voter))
             .await
             .unwrap_or_else(|_| panic!("vote {} should be added", i + 2));
         assert_eq!(
@@ -282,7 +287,12 @@ async fn test_p2p_dynamic_max_rounds() {
     let mut last_proposal = proposal;
     for (i, voter) in voters.iter().enumerate() {
         last_proposal = service
-            .cast_vote_and_get_proposal(&scope, last_proposal.proposal_id, VOTE_YES, voter.clone())
+            .cast_vote_and_get_proposal(
+                &scope,
+                last_proposal.proposal_id,
+                VOTE_YES,
+                wrap(voter.clone()),
+            )
             .await
             .unwrap_or_else(|_| panic!("vote {} should be added", i + 1));
         assert_eq!(
@@ -373,7 +383,7 @@ async fn test_p2p_ceil_calculation_edge_cases() {
                     &scope,
                     last_proposal.proposal_id,
                     VOTE_YES,
-                    voter.clone(),
+                    wrap(voter.clone()),
                 )
                 .await
                 .unwrap_or_else(|_| panic!("vote {} for n={} should succeed", i + 1, n));
@@ -411,21 +421,21 @@ async fn test_gossipsub_batch_vote_processing() {
 
     // Add votes to the proposal (simulating votes received from network)
     let voter1 = PrivateKeySigner::random();
-    let vote1 = build_vote(&proposal, VOTE_YES, voter1)
+    let vote1 = build_vote(&proposal, VOTE_YES, wrap(voter1))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote1);
     proposal.round = 2; // Gossipsub: round 2 after first vote
 
     let voter2 = PrivateKeySigner::random();
-    let vote2 = build_vote(&proposal, VOTE_YES, voter2)
+    let vote2 = build_vote(&proposal, VOTE_YES, wrap(voter2))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote2);
     // Round stays at 2 for gossipsub
 
     let voter3 = PrivateKeySigner::random();
-    let vote3 = build_vote(&proposal, VOTE_YES, voter3)
+    let vote3 = build_vote(&proposal, VOTE_YES, wrap(voter3))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote3);
@@ -443,7 +453,7 @@ async fn test_gossipsub_batch_vote_processing() {
     // Verify by casting another vote and checking the proposal
     let voter4 = PrivateKeySigner::random();
     let final_proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, voter4)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter4))
         .await
         .expect("additional vote should succeed");
     assert_eq!(
@@ -484,7 +494,7 @@ async fn test_p2p_batch_vote_processing() {
     }
 
     for (i, voter) in voters.iter().enumerate() {
-        let vote = build_vote(&proposal, VOTE_YES, voter.clone())
+        let vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
             .await
             .expect("vote should be created");
         proposal.votes.push(vote);
@@ -518,7 +528,7 @@ async fn test_p2p_batch_vote_processing() {
     // Try to add one more vote - should fail because consensus is already reached
     let voter7 = PrivateKeySigner::random();
     let _vote_result = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter7)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter7))
         .await;
 
     // The vote might succeed (returns vote) but won't be added because session reached consensus
@@ -574,7 +584,7 @@ async fn test_consensus_reachable_in_both_modes() {
 
     for voter in voters1 {
         service
-            .cast_vote(&scope1, proposal1.proposal_id, VOTE_YES, voter)
+            .cast_vote(&scope1, proposal1.proposal_id, VOTE_YES, wrap(voter))
             .await
             .expect("vote should succeed");
     }
@@ -614,7 +624,7 @@ async fn test_consensus_reachable_in_both_modes() {
 
     for voter in voters2 {
         service
-            .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, voter)
+            .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter))
             .await
             .expect("vote should succeed");
     }
@@ -652,7 +662,7 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote should be added");
 
@@ -685,13 +695,18 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .expect("proposal should be created");
 
     let proposal2 = service
-        .cast_vote_and_get_proposal(&scope2, proposal2.proposal_id, VOTE_YES, proposal_owner2)
+        .cast_vote_and_get_proposal(
+            &scope2,
+            proposal2.proposal_id,
+            VOTE_YES,
+            wrap(proposal_owner2),
+        )
         .await
         .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, voter2)
+        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote");
 
@@ -724,13 +739,18 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .expect("proposal should be created");
 
     let proposal3 = service
-        .cast_vote_and_get_proposal(&scope3, proposal3.proposal_id, VOTE_YES, proposal_owner3)
+        .cast_vote_and_get_proposal(
+            &scope3,
+            proposal3.proposal_id,
+            VOTE_YES,
+            wrap(proposal_owner3),
+        )
         .await
         .expect("first vote");
 
     let voter3 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope3, proposal3.proposal_id, VOTE_NO, voter3)
+        .cast_vote(&scope3, proposal3.proposal_id, VOTE_NO, wrap(voter3))
         .await
         .expect("second vote");
 
@@ -774,7 +794,7 @@ async fn test_n_gt_2_consensus_requirements() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote");
 
@@ -794,7 +814,7 @@ async fn test_n_gt_2_consensus_requirements() {
 
     let voter2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter2)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote");
 
@@ -840,7 +860,7 @@ async fn test_expired_proposal_rejected() {
     sleep(Duration::from_secs(EXPIRATION_WAIT_TIME_2_SECOND)).await;
     let voter = PrivateKeySigner::random();
     let err = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter))
         .await
         .expect_err("Should reject vote on expired proposal");
 
@@ -875,7 +895,7 @@ async fn test_timestamp_replay_attack_protection() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote");
 
@@ -887,7 +907,7 @@ async fn test_timestamp_replay_attack_protection() {
         .saturating_sub(EXPIRATION * 2); // More than expiration time
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, voter.clone())
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
         .await
         .expect("create vote");
 
@@ -942,25 +962,25 @@ async fn test_equality_of_votes_handling() {
         .expect("proposal should be created");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, voter2)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
         .await
         .expect("second vote");
 
     let voter3 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, voter3)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, wrap(voter3))
         .await
         .expect("third vote");
 
     let voter4 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, voter4)
+        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, wrap(voter4))
         .await
         .expect("fourth vote");
 
@@ -1002,25 +1022,30 @@ async fn test_equality_of_votes_handling() {
         .expect("proposal should be created");
 
     let proposal2 = service
-        .cast_vote_and_get_proposal(&scope2, proposal2.proposal_id, VOTE_YES, proposal_owner2)
+        .cast_vote_and_get_proposal(
+            &scope2,
+            proposal2.proposal_id,
+            VOTE_YES,
+            wrap(proposal_owner2),
+        )
         .await
         .expect("first vote");
 
     let voter2_2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, voter2_2)
+        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter2_2))
         .await
         .expect("second vote");
 
     let voter3_2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, voter3_2)
+        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, wrap(voter3_2))
         .await
         .expect("third vote");
 
     let voter4_2 = PrivateKeySigner::random();
     service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, voter4_2)
+        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, wrap(voter4_2))
         .await
         .expect("fourth vote");
 

--- a/tests/storage_stream_tests.rs
+++ b/tests/storage_stream_tests.rs
@@ -1,4 +1,5 @@
 use futures::StreamExt;
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
 use hashgraph_like_consensus::{
     scope::ScopeID,
@@ -26,8 +27,11 @@ fn make_session(name: &str) -> ConsensusSession {
     .into_proposal()
     .expect("proposal");
 
-    let (session, _) =
-        ConsensusSession::from_proposal(proposal, ConsensusConfig::gossipsub()).expect("session");
+    let (session, _) = ConsensusSession::from_proposal::<EthereumConsensusSigner>(
+        proposal,
+        ConsensusConfig::gossipsub(),
+    )
+    .expect("session");
     session
 }
 

--- a/tests/vote_tests.rs
+++ b/tests/vote_tests.rs
@@ -4,9 +4,14 @@ use hashgraph_like_consensus::{
     scope::ScopeID,
     service::DefaultConsensusService,
     session::ConsensusConfig,
+    signing::EthereumConsensusSigner,
     types::CreateProposalRequest,
     utils::{build_vote, validate_proposal},
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE: &str = "vote_scope";
 const PROPOSAL_NAME: &str = "Vote Test Proposal";
@@ -46,12 +51,12 @@ async fn test_received_hash_for_new_voter() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote");
 
     let other_voter = PrivateKeySigner::random();
-    let vote = build_vote(&proposal, VOTE_YES, other_voter)
+    let vote = build_vote(&proposal, VOTE_YES, wrap(other_voter))
         .await
         .expect("second vote");
 
@@ -66,7 +71,8 @@ async fn test_received_hash_for_new_voter() {
 
     let mut proposal_with_vote = proposal.clone();
     proposal_with_vote.votes.push(vote);
-    validate_proposal(&proposal_with_vote).expect("proposal with second voter should validate");
+    validate_proposal::<EthereumConsensusSigner>(&proposal_with_vote)
+        .expect("proposal with second voter should validate");
 }
 
 #[tokio::test]
@@ -97,13 +103,13 @@ async fn test_parent_hash_for_same_voter() {
             &scope,
             proposal.proposal_id,
             VOTE_YES,
-            proposal_owner.clone(),
+            wrap(proposal_owner.clone()),
         )
         .await
         .expect("proposal_owner vote");
 
     // Create a second vote from the same voter to exercise parent_hash logic.
-    let second_vote = build_vote(&proposal, VOTE_NO, proposal_owner)
+    let second_vote = build_vote(&proposal, VOTE_NO, wrap(proposal_owner))
         .await
         .expect("second vote");
 
@@ -118,6 +124,6 @@ async fn test_parent_hash_for_same_voter() {
 
     let mut proposal_with_vote = proposal.clone();
     proposal_with_vote.votes.push(second_vote);
-    validate_proposal(&proposal_with_vote)
+    validate_proposal::<EthereumConsensusSigner>(&proposal_with_vote)
         .expect("proposal with parent hash chain should validate");
 }

--- a/tests/vote_validation_tests.rs
+++ b/tests/vote_validation_tests.rs
@@ -1,4 +1,5 @@
 use alloy::signers::{Signer, local::PrivateKeySigner};
+use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
 use prost::Message;
 
@@ -10,6 +11,10 @@ use hashgraph_like_consensus::{
     types::CreateProposalRequest,
     utils::{build_vote, compute_vote_hash, validate_proposal},
 };
+
+fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
+    EthereumConsensusSigner::new(signer)
+}
 
 const SCOPE: &str = "validation_scope";
 const PROPOSAL_NAME: &str = "Proposal";
@@ -66,12 +71,12 @@ async fn test_vote_created_with_helper_is_valid() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let vote = build_vote(&proposal, VOTE_YES, voter)
+    let vote = build_vote(&proposal, VOTE_YES, wrap(voter))
         .await
         .expect("vote should be created");
 
@@ -105,12 +110,14 @@ async fn test_invalid_signature_is_rejected() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, voter).await.expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
+        .await
+        .expect("vote");
 
     let wrong_signer = PrivateKeySigner::random();
     let vote_bytes = vote.encode_to_vec();
@@ -123,7 +130,8 @@ async fn test_invalid_signature_is_rejected() {
     let mut invalid_proposal = proposal.clone();
     invalid_proposal.votes.push(vote);
 
-    let err = validate_proposal(&invalid_proposal).expect_err("validation should fail");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid_proposal)
+        .expect_err("validation should fail");
     assert!(
         matches!(err, ConsensusError::InvalidVoteSignature),
         "error: {err:?}"
@@ -154,17 +162,17 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, proposal_owner)
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("proposal_owner vote");
 
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, voter_one)
+    let vote_one = build_vote(&proposal, VOTE_YES, wrap(voter_one))
         .await
         .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, voter_two.clone())
+    let mut vote_two = build_vote(&proposal, VOTE_NO, wrap(voter_two.clone()))
         .await
         .expect("vote two");
 
@@ -183,7 +191,8 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
     invalid.votes.push(vote_one);
     invalid.votes.push(vote_two);
 
-    let err = validate_proposal(&invalid).expect_err("should fail chain validation");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("should fail chain validation");
     assert!(
         matches!(err, ConsensusError::ReceivedHashMismatch),
         "error: {err:?}"
@@ -213,7 +222,7 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote");
     vote.vote_owner.clear();
@@ -221,7 +230,8 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
     let mut invalid = proposal;
     invalid.votes.push(vote);
 
-    let err = validate_proposal(&invalid).expect_err("empty vote owner should fail");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("empty vote owner should fail");
     assert!(matches!(err, ConsensusError::EmptyVoteOwner));
 }
 
@@ -248,7 +258,7 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote");
     vote.vote_hash.clear();
@@ -256,7 +266,8 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
     let mut invalid = proposal;
     invalid.votes.push(vote);
 
-    let err = validate_proposal(&invalid).expect_err("empty vote hash should fail");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("empty vote hash should fail");
     assert!(matches!(err, ConsensusError::EmptyVoteHash));
 }
 
@@ -283,7 +294,7 @@ async fn test_validate_proposal_rejects_empty_signature() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote");
     vote.signature.clear();
@@ -291,7 +302,8 @@ async fn test_validate_proposal_rejects_empty_signature() {
     let mut invalid = proposal;
     invalid.votes.push(vote);
 
-    let err = validate_proposal(&invalid).expect_err("empty signature should fail");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("empty signature should fail");
     assert!(matches!(err, ConsensusError::EmptySignature));
 }
 
@@ -318,7 +330,7 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, proposal_owner)
+    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
         .await
         .expect("vote");
     vote.signature = vec![7; 64];
@@ -326,14 +338,11 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
     let mut invalid = proposal;
     invalid.votes.push(vote);
 
-    let err = validate_proposal(&invalid).expect_err("invalid signature length should fail");
-    assert!(matches!(
-        err,
-        ConsensusError::MismatchedLength {
-            expect: 65,
-            actual: 64
-        }
-    ));
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("invalid signature length should fail");
+    // Signature-length checks now live in the scheme and surface as a
+    // SignatureScheme error rather than a protocol-level MismatchedLength variant.
+    assert!(matches!(err, ConsensusError::SignatureScheme(_)));
 }
 
 #[tokio::test]
@@ -362,10 +371,10 @@ async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, voter_one)
+    let vote_one = build_vote(&proposal, VOTE_YES, wrap(voter_one))
         .await
         .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, voter_two.clone())
+    let mut vote_two = build_vote(&proposal, VOTE_NO, wrap(voter_two.clone()))
         .await
         .expect("vote two");
 
@@ -377,6 +386,7 @@ async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
     invalid.votes.push(vote_one);
     invalid.votes.push(vote_two);
 
-    let err = validate_proposal(&invalid).expect_err("parent hash owner mismatch should fail");
+    let err = validate_proposal::<EthereumConsensusSigner>(&invalid)
+        .expect_err("parent hash owner mismatch should fail");
     assert!(matches!(err, ConsensusError::ParentHashMismatch));
 }


### PR DESCRIPTION
## Summary

- Decouple the consensus core from Ethereum-specific signing by introducing a single `ConsensusSignatureScheme` trait (`identity` + async `sign` + static `verify`) in `src/signing.rs`.
- `ConsensusService<Scope, Storage, Event, Signer>` now carries the scheme as a generic param via `PhantomData`; `validate_proposal`, `validate_vote`, and `ConsensusSession` helpers are generic over `Signer`.
- `EthereumConsensusSigner` wraps `alloy::signers::local::PrivateKeySigner` and is the default scheme used by `DefaultConsensusService`. Embedders can plug in Ed25519, HSM-backed signers, libchat accounts, or any other scheme.
- Sign/verify errors collapse into a single `ConsensusSchemeError` thiserror enum (`Sign` / `Verify` variants). `ConsensusError::MismatchedLength` and `InvalidSignature` are removed; scheme-level failures surface via `ConsensusError::SignatureScheme(_)`.
- `tests/custom_scheme_tests.rs` exercises the generic path end-to-end with a non-Ethereum stub scheme, proving the abstraction holds.
- Bumps the crate to `0.3.0` with CHANGELOG migration notes and refreshed README.

## Breaking change

`cast_vote`, `build_vote`, and `validate_proposal` now require a `ConsensusSignatureScheme`. Migrate by wrapping existing signers:

```rust
// before
service.cast_vote(&scope, id, true, private_key_signer).await?;

// after
use hashgraph_like_consensus::signing::EthereumConsensusSigner;
service.cast_vote(&scope, id, true, EthereumConsensusSigner::new(private_key_signer)).await?;
```

`validate_proposal::<EthereumConsensusSigner>(&proposal)?;` for direct callers.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features --tests -- -D warnings`
- [x] `cargo test --all-features --tests` (all 91 tests pass, including the new `custom_scheme_tests`)
- [x] `cargo test --doc`
- [ ] CI green