### PR TITLE
feat(service)!: hold signer in ConsensusService, drop per-call signer arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.4.0
+
+**Breaking** — `ConsensusService` now holds its peer's signer instead of
+taking one per call. `cast_vote` and friends drop the signer parameter.
+
+### Changed
+
+- `ConsensusService<Scope, Storage, Event, Signer>` now stores a `Signer`
+  instance (previously `PhantomData<fn() -> Signer>`). The signer represents
+  this peer's identity for the lifetime of the service; storage, event bus,
+  and signer are all peer-scoped held state.
+- `ConsensusSignatureScheme` now requires `Clone + Send + Sync + 'static`,
+  matching `ConsensusStorage` and `ConsensusEventBus`.
+- `cast_vote` and `cast_vote_and_get_proposal` drop the `signer` parameter
+  and use the service's held signer:
+  ```rust
+  // before
+  service.cast_vote(&scope, id, choice, signer).await?;
+  // after
+  service.cast_vote(&scope, id, choice).await?;
+  ```
+- `ConsensusService::new_with_components` now takes the signer:
+  `new_with_components(storage, event_bus, signer, max_sessions_per_scope)`.
+- `DefaultConsensusService::new(signer)` and
+  `new_with_max_sessions(signer, max)` require a signer. `Default::default()`
+  is removed (no sensible identity to fabricate).
+- `utils::build_vote` now takes `signer: &Signer` (was by value).
+
+### Added
+
+- `ConsensusService::signer(&self) -> &Signer` accessor, mirroring
+  `storage()` and `event_bus()`.
+
+### Migration
+
+```rust
+// before
+let service = DefaultConsensusService::default();
+service.cast_vote(&scope, id, true, signer).await?;
+
+// after
+let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+let service = DefaultConsensusService::new(signer);
+service.cast_vote(&scope, id, true).await?;
+```
+
+For multi-peer setups (one process simulating many identities), construct
+one `ConsensusService` per peer with shared storage and (optionally) a
+shared event bus — see the README "Service shape" section.
+
 ## 0.3.0
 
 **Breaking** — the crate is no longer hard-coded to Ethereum signing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashgraph-like-consensus"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy",
  "alloy-signer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashgraph-like-consensus"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "A lightweight Rust library for making binary decisions in networks using hashgraph-style consensus"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ use alloy::signers::local::PrivateKeySigner;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let service = DefaultConsensusService::default();
-    let scope = ScopeID::from("example-scope");
     let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+    let service = DefaultConsensusService::new(signer.clone());
+    let scope = ScopeID::from("example-scope");
 
     // Create a proposal
     let proposal = service
@@ -61,10 +61,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
-    // Cast a vote
-    let vote = service
-        .cast_vote(&scope, proposal.proposal_id, true, signer)
-        .await?;
+    // Cast a vote — the service uses its held signer.
+    let vote = service.cast_vote(&scope, proposal.proposal_id, true).await?;
     println!("Recorded vote {}", vote.vote_id);
 
     Ok(())
@@ -127,15 +125,20 @@ use hashgraph_like_consensus::{
     signing::EthereumConsensusSigner,
     storage::InMemoryConsensusStorage,
 };
+use alloy::signers::local::PrivateKeySigner;
 
 // Shared storage across all conversations.
 let storage = InMemoryConsensusStorage::<ScopeID>::new();
+
+// This peer's signer — built once and cloned into each conversation's service.
+let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
 
 // One service per conversation, each with its own event bus.
 let conv_a: ConsensusService<_, _, _, EthereumConsensusSigner> =
     ConsensusService::new_with_components(
         storage.clone(),                // shared backing data
         BroadcastEventBus::default(),   // private bus for this conversation
+        signer.clone(),                 // same identity in every conversation
         10,
     );
 
@@ -143,6 +146,7 @@ let conv_b: ConsensusService<_, _, _, EthereumConsensusSigner> =
     ConsensusService::new_with_components(
         storage.clone(),
         BroadcastEventBus::default(),
+        signer.clone(),
         10,
     );
 
@@ -175,7 +179,7 @@ orchestration. Your application is responsible for:
 | **Network propagation**              | The library performs no I/O. When you create a proposal or cast a vote, you must gossip it to peers yourself. When a message arrives from the network, call `process_incoming_proposal` or `process_incoming_vote`.                                |
 | **Timeout scheduling**               | The library does not spawn timers. You must schedule a timer for each proposal (using `consensus_timeout()` from the config) and call `handle_consensus_timeout` when it fires. Without this, proposals with offline voters stay `Active` forever. |
 | **`expected_voters_count` accuracy** | This value drives all threshold math (`ceil(2n/3)` quorum, silent peer counting). If it doesn't match the actual group size, consensus results will be wrong.                                                                                      |
-| **Signer management**                | You provide a `ConsensusSignatureScheme` value when casting a vote (e.g. `EthereumConsensusSigner::new(private_key)`). The library uses `identity()` for the voter address. Each identity may vote at most once per proposal.                       |
+| **Signer management**                | You construct each `ConsensusService` with the peer's `ConsensusSignatureScheme` value (e.g. `EthereumConsensusSigner::new(private_key)`). `cast_vote` uses that held signer. Each identity may vote at most once per proposal.                     |
 | **Proposal ID tracking**             | The library generates a `proposal_id` on creation. You must store it and pass it to every subsequent call (`cast_vote`, `handle_consensus_timeout`, etc.).                                                                                         |
 | **Session eviction awareness**       | The default service keeps at most 10 sessions per scope (configurable via `new_with_max_sessions`). Older sessions are silently dropped when the limit is exceeded. Archive results before they are evicted.                                       |
 
@@ -184,20 +188,29 @@ orchestration. Your application is responsible for:
 ### Creating a Service
 
 ```rust
-use hashgraph_like_consensus::service::{ConsensusService, DefaultConsensusService};
+use hashgraph_like_consensus::{
+    service::{ConsensusService, DefaultConsensusService},
+    signing::EthereumConsensusSigner,
+};
+use alloy::signers::local::PrivateKeySigner;
 
-// Default: in-memory storage, broadcast events, EthereumConsensusSigner scheme,
-// 10 max sessions per scope
-let service = DefaultConsensusService::default();
+let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
 
-// Custom session limit (still the Ethereum default scheme)
-let service = DefaultConsensusService::new_with_max_sessions(20);
+// In-memory storage + broadcast events + this peer's signer. 10 sessions per scope.
+let service = DefaultConsensusService::new(signer.clone());
 
-// Fully custom: plug in your own storage, event bus, and signature scheme
-// (the scheme is picked via the type — typically via a type alias)
+// Custom session limit (still the Ethereum default scheme).
+let service = DefaultConsensusService::new_with_max_sessions(signer.clone(), 20);
+
+// Fully custom: plug in your own storage, event bus, signer, and signature scheme.
 let service: ConsensusService<MyScope, MyStorage, MyEvents, MyScheme> =
-    ConsensusService::new_with_components(my_storage, my_event_bus, 10);
+    ConsensusService::new_with_components(my_storage, my_event_bus, my_signer, 10);
 ```
+
+`signer` is held inside the service and used for every outgoing vote — see
+[Casting and Processing Votes](#casting-and-processing-votes). Access via
+`service.signer()` if you need its identity bytes (e.g. for proposal owner
+fields).
 
 ### Configuring a Scope
 
@@ -264,20 +277,15 @@ service.process_incoming_proposal(&scope, proposal).await?;
 ### Casting and Processing Votes
 
 ```rust
-use hashgraph_like_consensus::signing::EthereumConsensusSigner;
-use alloy::signers::local::PrivateKeySigner;
+// Cast your vote (yes = true, no = false) using the service's held signer.
+let vote = service.cast_vote(&scope, proposal_id, true).await?;
 
-let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
-
-// Cast your vote (yes = true, no = false)
-let vote = service.cast_vote(&scope, proposal_id, true, signer.clone()).await?;
-
-// Cast a vote and get the updated proposal (useful for gossiping)
+// Cast a vote and get the updated proposal (useful for gossiping).
 let proposal = service
-    .cast_vote_and_get_proposal(&scope, proposal_id, true, signer)
+    .cast_vote_and_get_proposal(&scope, proposal_id, true)
     .await?;
 
-// Process a vote received from the network (uses the service's scheme to verify)
+// Process a vote received from the network (uses the service's scheme to verify).
 service.process_incoming_vote(&scope, vote).await?;
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@
 //! use alloy::signers::local::PrivateKeySigner;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let service = DefaultConsensusService::default();
-//! let scope = ScopeID::from("my-scope");
 //! let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+//! let service = DefaultConsensusService::new(signer.clone());
+//! let scope = ScopeID::from("my-scope");
 //!
 //! let proposal = service
 //!     .create_proposal(
@@ -79,9 +79,7 @@
 //!     )
 //!     .await?;
 //!
-//! let vote = service
-//!     .cast_vote(&scope, proposal.proposal_id, true, signer)
-//!     .await?;
+//! let vote = service.cast_vote(&scope, proposal.proposal_id, true).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,14 +22,19 @@ use crate::{
 /// This is the main entry point for using the consensus service.
 /// It handles creating proposals, processing votes, and managing timeouts.
 ///
+/// Each `ConsensusService` represents **one peer's view**: it holds the
+/// storage handle, the event bus, and that peer's signer. The multi-peer
+/// pattern is one service per peer with shared storage and (optionally)
+/// shared event bus — see the README "Service shape" section.
+///
 /// Generic parameters:
 ///
 /// - `Scope`: scope key type (see [`ConsensusScope`]).
 /// - `Storage`: storage backend (see [`ConsensusStorage`]).
 /// - `Event`: event bus backend (see [`ConsensusEventBus`]).
-/// - `Signer`: signature scheme (see [`ConsensusSignatureScheme`]). Carried only
-///   as a type; the service calls `Signer::verify` statically when validating
-///   incoming votes. All peers on a network must agree on this type.
+/// - `Signer`: signature scheme (see [`ConsensusSignatureScheme`]).
+///   The held instance signs this peer's outgoing votes; the same type
+///   provides `Signer::verify` for validating incoming votes.
 pub struct ConsensusService<Scope, Storage, Event, Signer>
 where
     Scope: ConsensusScope,
@@ -40,8 +45,8 @@ where
     storage: Storage,
     max_sessions_per_scope: usize,
     event_bus: Event,
+    signer: Signer,
     _scope: PhantomData<Scope>,
-    _scheme: PhantomData<fn() -> Signer>,
 }
 
 impl<Scope, Storage, Event, Signer> Clone for ConsensusService<Scope, Storage, Event, Signer>
@@ -56,8 +61,8 @@ where
             storage: self.storage.clone(),
             max_sessions_per_scope: self.max_sessions_per_scope,
             event_bus: self.event_bus.clone(),
+            signer: self.signer.clone(),
             _scope: PhantomData,
-            _scheme: PhantomData,
         }
     }
 }
@@ -74,9 +79,10 @@ pub type DefaultConsensusService = ConsensusService<
 >;
 
 impl DefaultConsensusService {
-    /// Create a service with default settings (10 max sessions per scope).
-    fn new() -> Self {
-        Self::new_with_max_sessions(10)
+    /// Create a service with in-memory storage, broadcast events, and the
+    /// given signer. Defaults to 10 max sessions per scope.
+    pub fn new(signer: EthereumConsensusSigner) -> Self {
+        Self::new_with_max_sessions(signer, 10)
     }
 
     /// Create a service with a custom limit on how many sessions can exist per scope.
@@ -84,18 +90,16 @@ impl DefaultConsensusService {
     /// When the limit is reached, older sessions are automatically removed to make room.
     /// Eviction is silent — no event is emitted. Archive results you need before they
     /// are evicted.
-    pub fn new_with_max_sessions(max_sessions_per_scope: usize) -> Self {
+    pub fn new_with_max_sessions(
+        signer: EthereumConsensusSigner,
+        max_sessions_per_scope: usize,
+    ) -> Self {
         Self::new_with_components(
             InMemoryConsensusStorage::new(),
             BroadcastEventBus::default(),
+            signer,
             max_sessions_per_scope,
         )
-    }
-}
-
-impl Default for DefaultConsensusService {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -117,14 +121,15 @@ where
     pub fn new_with_components(
         storage: Storage,
         event_bus: Event,
+        signer: Signer,
         max_sessions_per_scope: usize,
     ) -> Self {
         Self {
             storage,
             max_sessions_per_scope,
             event_bus,
+            signer,
             _scope: PhantomData,
-            _scheme: PhantomData,
         }
     }
 
@@ -143,6 +148,14 @@ where
     /// Use this to [`subscribe`](ConsensusEventBus::subscribe) to consensus events.
     pub fn event_bus(&self) -> &Event {
         &self.event_bus
+    }
+
+    /// Access this peer's signer.
+    ///
+    /// Use this to read the peer's identity (e.g. for proposal owner fields):
+    /// `service.signer().identity()`.
+    pub fn signer(&self) -> &Signer {
+        &self.signer
     }
 
     // ── Consensus operations (business logic) ──────────────────────────
@@ -187,30 +200,25 @@ where
         Ok(proposal)
     }
 
-    /// Cast a vote on an active proposal.
+    /// Cast a vote on an active proposal using this service's held signer.
     ///
-    /// The vote is cryptographically signed with `signer` and linked into the
-    /// hashgraph chain. Returns the signed [`Vote`] for network propagation.
-    /// Each voter can only vote once per proposal.
-    ///
-    /// The signer is of the same scheme `Signer` that the service uses for
-    /// verification, so signatures it produces are guaranteed to round-trip
-    /// through [`process_incoming_vote`](Self::process_incoming_vote).
+    /// The vote is cryptographically signed and linked into the hashgraph
+    /// chain. Returns the signed [`Vote`] for network propagation. Each peer
+    /// (identity) can only vote once per proposal.
     pub async fn cast_vote(
         &self,
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
-        signer: Signer,
     ) -> Result<Vote, ConsensusError> {
         let session = self.get_session(scope, proposal_id).await?;
         validate_proposal_timestamp(session.proposal.expiration_timestamp)?;
 
-        if session.votes.contains_key(signer.identity()) {
+        if session.votes.contains_key(self.signer.identity()) {
             return Err(ConsensusError::UserAlreadyVoted);
         }
 
-        let vote = build_vote(&session.proposal, choice, signer).await?;
+        let vote = build_vote(&session.proposal, choice, &self.signer).await?;
         let vote_clone = vote.clone();
         let transition = self
             .update_session(scope, proposal_id, move |session| {
@@ -230,9 +238,8 @@ where
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
-        signer: Signer,
     ) -> Result<Proposal, ConsensusError> {
-        self.cast_vote(scope, proposal_id, choice, signer).await?;
+        self.cast_vote(scope, proposal_id, choice).await?;
         let session = self.get_session(scope, proposal_id).await?;
         Ok(session.proposal)
     }
@@ -360,11 +367,18 @@ where
     ///
     /// # Example
     /// ```rust,no_run
-    /// use hashgraph_like_consensus::{scope_config::NetworkType, scope::ScopeID, service::DefaultConsensusService};
+    /// use hashgraph_like_consensus::{
+    ///     scope::ScopeID,
+    ///     scope_config::NetworkType,
+    ///     service::DefaultConsensusService,
+    ///     signing::EthereumConsensusSigner,
+    /// };
+    /// use alloy::signers::local::PrivateKeySigner;
     /// use std::time::Duration;
     ///
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///   let service = DefaultConsensusService::default();
+    ///   let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
+    ///   let service = DefaultConsensusService::new(signer);
     ///   let scope = ScopeID::from("my_scope");
     ///
     ///   // Initialize new scope

--- a/src/session.rs
+++ b/src/session.rs
@@ -437,28 +437,28 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote)
-        let vote1 = build_vote(&session.proposal, true, wrap(signer1))
+        let vote1 = build_vote(&session.proposal, true, &wrap(signer1))
             .await
             .unwrap();
         session.add_vote(vote1).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (second vote)
-        let vote2 = build_vote(&session.proposal, false, wrap(signer2))
+        let vote2 = build_vote(&session.proposal, false, &wrap(signer2))
             .await
             .unwrap();
         session.add_vote(vote2).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (third vote)
-        let vote3 = build_vote(&session.proposal, true, wrap(signer3))
+        let vote3 = build_vote(&session.proposal, true, &wrap(signer3))
             .await
             .unwrap();
         session.add_vote(vote3).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (fourth vote) - should succeed
-        let vote4 = build_vote(&session.proposal, true, wrap(signer4))
+        let vote4 = build_vote(&session.proposal, true, &wrap(signer4))
             .await
             .unwrap();
         session.add_vote(vote4).unwrap();
@@ -492,7 +492,7 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote, 1 vote total)
-        let vote1 = build_vote(&session.proposal, true, wrap(signer1))
+        let vote1 = build_vote(&session.proposal, true, &wrap(signer1))
             .await
             .unwrap();
         session.add_vote(vote1).unwrap();
@@ -500,7 +500,7 @@ mod tests {
         assert_eq!(session.votes.len(), 1);
 
         // Round 2 -> Round 3 (second vote, 2 votes total) - should succeed
-        let vote2 = build_vote(&session.proposal, false, wrap(signer2))
+        let vote2 = build_vote(&session.proposal, false, &wrap(signer2))
             .await
             .unwrap();
         session.add_vote(vote2).unwrap();
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(session.votes.len(), 2);
 
         // Round 3 -> Round 4 (third vote, 3 votes total) - should succeed
-        let vote3 = build_vote(&session.proposal, true, wrap(signer3))
+        let vote3 = build_vote(&session.proposal, true, &wrap(signer3))
             .await
             .unwrap();
         session.add_vote(vote3).unwrap();
@@ -516,7 +516,7 @@ mod tests {
         assert_eq!(session.votes.len(), 3);
 
         // Round 4 -> Round 5 (fourth vote, 4 votes total) - should succeed (dynamic limit = 4)
-        let vote4 = build_vote(&session.proposal, true, wrap(signer4))
+        let vote4 = build_vote(&session.proposal, true, &wrap(signer4))
             .await
             .unwrap();
         session.add_vote(vote4).unwrap();
@@ -524,7 +524,7 @@ mod tests {
         assert_eq!(session.votes.len(), 4);
 
         // Fifth vote would exceed dynamic max_round_limit (=4 votes)
-        let vote5 = build_vote(&session.proposal, true, wrap(signer5))
+        let vote5 = build_vote(&session.proposal, true, &wrap(signer5))
             .await
             .unwrap();
         let err = session.add_vote(vote5).unwrap_err();
@@ -577,7 +577,7 @@ mod tests {
         let mut failed_session =
             ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
         failed_session.state = ConsensusState::Failed;
-        let vote = build_vote(&failed_session.proposal, true, wrap(signer.clone()))
+        let vote = build_vote(&failed_session.proposal, true, &wrap(signer.clone()))
             .await
             .unwrap();
         let err = failed_session.add_vote(vote).unwrap_err();
@@ -586,7 +586,7 @@ mod tests {
         // Finalized sessions return existing transition/result.
         let mut finalized_session = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
         finalized_session.state = ConsensusState::ConsensusReached(true);
-        let vote = build_vote(&finalized_session.proposal, true, wrap(signer))
+        let vote = build_vote(&finalized_session.proposal, true, &wrap(signer))
             .await
             .unwrap();
         let transition = finalized_session.add_vote(vote).unwrap();
@@ -624,10 +624,10 @@ mod tests {
 
         // Duplicate owners are rejected before chain/signature checks.
         let mut dup_session = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
-        let vote1 = build_vote(&dup_session.proposal, true, wrap(signer.clone()))
+        let vote1 = build_vote(&dup_session.proposal, true, &wrap(signer.clone()))
             .await
             .unwrap();
-        let vote2 = build_vote(&dup_session.proposal, false, wrap(signer))
+        let vote2 = build_vote(&dup_session.proposal, false, &wrap(signer))
             .await
             .unwrap();
         let err = dup_session

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -37,7 +37,13 @@ pub use ethereum::EthereumConsensusSigner;
 ///
 /// All peers on a network must agree on the scheme, since they all verify
 /// each other's signatures using the same `verify` rule.
-pub trait ConsensusSignatureScheme: Send + Sync {
+///
+/// The trait inherits `Clone + Send + Sync + 'static` to mirror the
+/// [`ConsensusStorage`](crate::storage::ConsensusStorage) and
+/// [`ConsensusEventBus`](crate::events::ConsensusEventBus) traits — the
+/// [`ConsensusService`](crate::service::ConsensusService) holds an instance
+/// for the lifetime of the service and clones it when the service is cloned.
+pub trait ConsensusSignatureScheme: Clone + Send + Sync + 'static {
     /// Stable identity bytes for this signer (e.g. address, public key, account id).
     ///
     /// Written into [`Vote::vote_owner`] when the signer casts a vote and

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,7 +57,7 @@ pub fn compute_vote_hash(vote: &Vote) -> Vec<u8> {
 pub async fn build_vote<Signer: ConsensusSignatureScheme>(
     proposal: &Proposal,
     user_vote: bool,
-    signer: Signer,
+    signer: &Signer,
 ) -> Result<Vote, ConsensusError> {
     let now = current_timestamp()?;
 

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -3,14 +3,27 @@ use futures::future::join_all;
 use std::{sync::Arc, time::Duration};
 use tokio::{spawn, sync::Barrier, time::sleep};
 
-use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use hashgraph_like_consensus::{
-    error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
-    session::ConsensusConfig, storage::ConsensusStorage, types::CreateProposalRequest,
+    error::ConsensusError,
+    events::BroadcastEventBus,
+    scope::ScopeID,
+    service::{ConsensusService, DefaultConsensusService},
+    session::ConsensusConfig,
+    signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
+    storage::{ConsensusStorage, InMemoryConsensusStorage},
+    types::CreateProposalRequest,
 };
 
 fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
     EthereumConsensusSigner::new(signer)
+}
+
+fn peer_service(
+    storage: &InMemoryConsensusStorage<ScopeID>,
+    bus: &BroadcastEventBus<ScopeID>,
+    signer: EthereumConsensusSigner,
+) -> DefaultConsensusService {
+    ConsensusService::new_with_components(storage.clone(), bus.clone(), signer, 10)
 }
 
 const SCOPE: &str = "concurrency_scope";
@@ -26,26 +39,24 @@ const EXPECTED_VOTERS_COUNT_5: u32 = 5;
 
 const EXPECTED_PROPOSALS_COUNT_5: u32 = 5;
 
-fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
-    signer.address().as_slice().to_vec()
-}
-
 // Verifies 10 parallel votes succeed under gossipsub and reach consensus;
 #[tokio::test]
 async fn test_concurrent_vote_casting() {
-    let service = Arc::new(DefaultConsensusService::default());
+    let storage = InMemoryConsensusStorage::<ScopeID>::new();
+    let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
-    let proposal_owner = PrivateKeySigner::random();
+
+    let owner = peer_service(&storage, &bus, wrap(PrivateKeySigner::random()));
 
     // Use gossipsub mode (default) to allow all 10 votes in round 2
     // P2P mode would limit to ceil(2*10/3) = 7 votes, but we need 10 votes for this test
-    let proposal = service
+    let proposal = owner
         .create_proposal_with_config(
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
                 PROPOSAL_PAYLOAD,
-                owner_bytes(&proposal_owner),
+                owner.signer().identity().to_vec(),
                 EXPECTED_VOTERS_COUNT_10,
                 EXPIRATION,
                 true,
@@ -59,17 +70,17 @@ async fn test_concurrent_vote_casting() {
     let proposal_id = proposal.proposal_id;
     let barrier = Arc::new(Barrier::new(EXPECTED_VOTERS_COUNT_10 as usize));
 
+    // Each concurrent peer has its own service sharing storage + bus.
     let mut handles = Vec::new();
     for i in 0..EXPECTED_VOTERS_COUNT_10 {
-        let service_clone = Arc::clone(&service);
+        let storage = storage.clone();
+        let bus = bus.clone();
         let scope_clone = scope.clone();
         let barrier_clone = Arc::clone(&barrier);
         let handle = spawn(async move {
             barrier_clone.wait().await;
-            let voter = PrivateKeySigner::random();
-            service_clone
-                .cast_vote(&scope_clone, proposal_id, i % 2 == 0, wrap(voter))
-                .await
+            let peer = peer_service(&storage, &bus, wrap(PrivateKeySigner::random()));
+            peer.cast_vote(&scope_clone, proposal_id, i % 2 == 0).await
         });
         handles.push(handle);
     }
@@ -79,7 +90,7 @@ async fn test_concurrent_vote_casting() {
     assert_eq!(success_count, 10, "All 10 unique votes should succeed");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
-    let result = service
+    let result = owner
         .storage()
         .get_consensus_result(&scope, proposal_id)
         .await;
@@ -92,22 +103,24 @@ async fn test_concurrent_vote_casting() {
 // Test concurrent proposal creation and vote processing
 #[tokio::test]
 async fn test_concurrent_proposal_operations() {
-    let service = Arc::new(DefaultConsensusService::default());
+    let storage = InMemoryConsensusStorage::<ScopeID>::new();
+    let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
 
     let mut handles = Vec::new();
     for i in 0..EXPECTED_PROPOSALS_COUNT_5 {
-        let service_clone = Arc::clone(&service);
+        let storage = storage.clone();
+        let bus = bus.clone();
         let scope_clone = scope.clone();
         let handle = spawn(async move {
-            let proposal_owner = PrivateKeySigner::random();
-            service_clone
+            let proposal_owner = peer_service(&storage, &bus, wrap(PrivateKeySigner::random()));
+            proposal_owner
                 .create_proposal_with_config(
                     &scope_clone,
                     CreateProposalRequest::new(
                         format!("Proposal {i}"),
                         PROPOSAL_PAYLOAD,
-                        owner_bytes(&proposal_owner),
+                        proposal_owner.signer().identity().to_vec(),
                         EXPECTED_VOTERS_COUNT_3,
                         EXPIRATION,
                         true,
@@ -134,18 +147,22 @@ async fn test_concurrent_proposal_operations() {
 // Test that duplicate votes are properly rejected
 #[tokio::test]
 async fn test_concurrent_duplicate_vote_rejection() {
-    let service = Arc::new(DefaultConsensusService::default());
+    let storage = InMemoryConsensusStorage::<ScopeID>::new();
+    let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
-    let proposal_owner = PrivateKeySigner::random();
-    let voter = PrivateKeySigner::random();
 
-    let proposal = service
+    let owner_signer = wrap(PrivateKeySigner::random());
+    let voter_signer = wrap(PrivateKeySigner::random());
+
+    let owner = peer_service(&storage, &bus, owner_signer.clone());
+
+    let proposal = owner
         .create_proposal_with_config(
             &scope,
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
                 PROPOSAL_PAYLOAD,
-                owner_bytes(&proposal_owner),
+                owner_signer.identity().to_vec(),
                 EXPECTED_VOTERS_COUNT_3,
                 EXPIRATION,
                 true,
@@ -158,17 +175,15 @@ async fn test_concurrent_duplicate_vote_rejection() {
 
     let proposal_id = proposal.proposal_id;
 
-    // Try to cast the same vote concurrently multiple times
+    // Many parallel handles all try to cast as the SAME voter. The voter has
+    // one service; the concurrent cast_vote calls go through interior-mutable
+    // storage atomically, so only one should succeed.
+    let voter = Arc::new(peer_service(&storage, &bus, voter_signer.clone()));
     let mut handles = Vec::new();
     for _ in 0..EXPECTED_VOTERS_COUNT_5 {
-        let service_clone = Arc::clone(&service);
+        let voter = Arc::clone(&voter);
         let scope_clone = scope.clone();
-        let voter_clone = voter.clone();
-        let handle = spawn(async move {
-            service_clone
-                .cast_vote(&scope_clone, proposal_id, true, wrap(voter_clone))
-                .await
-        });
+        let handle = spawn(async move { voter.cast_vote(&scope_clone, proposal_id, true).await });
         handles.push(handle);
     }
 
@@ -178,7 +193,7 @@ async fn test_concurrent_duplicate_vote_rejection() {
         .map(|r| r.expect("Task should complete"))
         .collect();
 
-    let voter_address = owner_bytes(&voter);
+    let voter_address = voter_signer.identity().to_vec();
     let successful_votes: Vec<_> = vote_results
         .iter()
         .filter_map(|r| r.as_ref().ok())

--- a/tests/consensus_service_tests.rs
+++ b/tests/consensus_service_tests.rs
@@ -17,6 +17,40 @@ use hashgraph_like_consensus::{
     utils::{build_vote, compute_vote_hash},
 };
 
+async fn cast_remote_vote(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Vote,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
+    let vote = build_vote(&proposal, choice, signer).await?;
+    service.process_incoming_vote(scope, vote.clone()).await?;
+    Ok(vote)
+}
+
+async fn cast_remote_vote_and_get_proposal(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Proposal,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
+    service.storage().get_proposal(scope, proposal_id).await
+}
+
+fn make_service() -> DefaultConsensusService {
+    DefaultConsensusService::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
+}
+
 fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
     EthereumConsensusSigner::new(signer)
 }
@@ -72,15 +106,14 @@ async fn cast_vote_or_panic(
     signer: PrivateKeySigner,
     msg: &str,
 ) {
-    service
-        .cast_vote(scope, proposal_id, choice, wrap(signer))
+    cast_remote_vote(service, scope, proposal_id, choice, &wrap(signer))
         .await
         .expect(msg);
 }
 
 #[tokio::test]
 async fn test_basic_consensus_flow() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -101,10 +134,15 @@ async fn test_basic_consensus_flow() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("proposal_owner vote should succeed");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("proposal_owner vote should succeed");
 
     {
         let active = service
@@ -128,16 +166,26 @@ async fn test_basic_consensus_flow() {
     );
 
     let voter_two = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter_two))
-        .await
-        .expect("second vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter_two),
+    )
+    .await
+    .expect("second vote should succeed");
 
     let voter_three = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter_three))
-        .await
-        .expect("third vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter_three),
+    )
+    .await
+    .expect("third vote should succeed");
 
     // Now consensus should be reached
     let result = service
@@ -152,7 +200,10 @@ async fn test_basic_consensus_flow() {
 
 #[tokio::test]
 async fn test_multi_scope_isolation() {
-    let service = DefaultConsensusService::new_with_max_sessions(5);
+    let service = DefaultConsensusService::new_with_max_sessions(
+        EthereumConsensusSigner::new(PrivateKeySigner::random()),
+        5,
+    );
     let scope1 = ScopeID::from(SCOPE1_NAME);
     let scope2 = ScopeID::from(SCOPE2_NAME);
 
@@ -176,10 +227,15 @@ async fn test_multi_scope_isolation() {
         .await
         .expect("scope1 proposal");
 
-    service
-        .cast_vote_and_get_proposal(&scope1, proposal_1.proposal_id, VOTE_YES, wrap(signer1))
-        .await
-        .expect("scope1 proposal_owner vote");
+    cast_remote_vote_and_get_proposal(
+        &service,
+        &scope1,
+        proposal_1.proposal_id,
+        VOTE_YES,
+        &wrap(signer1),
+    )
+    .await
+    .expect("scope1 proposal_owner vote");
 
     let proposal_2 = service
         .create_proposal_with_config(
@@ -198,10 +254,15 @@ async fn test_multi_scope_isolation() {
         .await
         .expect("scope2 proposal");
 
-    service
-        .cast_vote_and_get_proposal(&scope2, proposal_2.proposal_id, VOTE_YES, wrap(signer2))
-        .await
-        .expect("scope2 proposal_owner vote");
+    cast_remote_vote_and_get_proposal(
+        &service,
+        &scope2,
+        proposal_2.proposal_id,
+        VOTE_YES,
+        &wrap(signer2),
+    )
+    .await
+    .expect("scope2 proposal_owner vote");
 
     {
         let active = service
@@ -231,7 +292,7 @@ async fn test_multi_scope_isolation() {
 
 #[tokio::test]
 async fn test_consensus_threshold_emits_event() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -253,17 +314,27 @@ async fn test_consensus_threshold_emits_event() {
         .await
         .expect("proposal should be created");
 
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("proposal_owner vote");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("proposal_owner vote");
 
     for _ in 0..3 {
         let signer = PrivateKeySigner::random();
-        service
-            .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(signer))
-            .await
-            .expect("additional vote");
+        cast_remote_vote(
+            &service,
+            &scope,
+            proposal.proposal_id,
+            VOTE_YES,
+            &wrap(signer),
+        )
+        .await
+        .expect("additional vote");
     }
 
     let proposal_id = proposal.proposal_id;
@@ -291,7 +362,7 @@ async fn test_consensus_threshold_emits_event() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_already_reached() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -342,7 +413,7 @@ async fn test_handle_consensus_timeout_already_reached() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_reaches_consensus() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -413,7 +484,7 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
 
@@ -492,7 +563,7 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -560,7 +631,7 @@ async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_insufficient_votes() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -654,7 +725,7 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_no_votes_liveness_true() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -703,7 +774,7 @@ async fn test_handle_consensus_timeout_no_votes_liveness_true() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_no_votes_liveness_false() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -752,7 +823,7 @@ async fn test_handle_consensus_timeout_no_votes_liveness_false() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from("scope_p2p_reaches_consensus");
     let proposal_owner = PrivateKeySigner::random();
@@ -819,7 +890,7 @@ async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from("scope_p2p_insufficient_votes");
     let proposal_owner = PrivateKeySigner::random();
@@ -888,9 +959,12 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
 
 #[tokio::test]
 async fn test_cast_vote_rejects_same_voter_twice() {
-    let service = DefaultConsensusService::default();
-    let scope = ScopeID::from(SCOPE1_NAME);
+    // Service-side dedup: cast_vote pre-checks the held signer's identity
+    // against the session's votes map and returns UserAlreadyVoted.
     let proposal_owner = PrivateKeySigner::random();
+    let signer = wrap(proposal_owner.clone());
+    let service = DefaultConsensusService::new(signer.clone());
+    let scope = ScopeID::from(SCOPE1_NAME);
 
     let proposal = service
         .create_proposal_with_config(
@@ -910,17 +984,12 @@ async fn test_cast_vote_rejects_same_voter_twice() {
         .expect("proposal should be created");
 
     service
-        .cast_vote(
-            &scope,
-            proposal.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner.clone()),
-        )
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES)
         .await
         .expect("first vote should succeed");
 
     let err = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
+        .cast_vote(&scope, proposal.proposal_id, VOTE_YES)
         .await
         .expect_err("second vote from same voter should fail");
 
@@ -932,7 +1001,7 @@ async fn test_cast_vote_rejects_same_voter_twice() {
 
 #[tokio::test]
 async fn test_process_incoming_proposal_rejects_duplicate_proposal() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -966,7 +1035,7 @@ async fn test_process_incoming_proposal_rejects_duplicate_proposal() {
 
 #[tokio::test]
 async fn test_process_incoming_vote_rejects_unknown_session() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
 
     let proposal_owner = PrivateKeySigner::random();
@@ -989,15 +1058,15 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
 
     let unknown_proposal_id = proposal.proposal_id.wrapping_add(1);
     let vote_owner = PrivateKeySigner::random();
-    let vote = service
-        .cast_vote(
-            &scope,
-            proposal.proposal_id,
-            VOTE_YES,
-            wrap(vote_owner.clone()),
-        )
-        .await
-        .expect("valid signed vote");
+    let vote = cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(vote_owner.clone()),
+    )
+    .await
+    .expect("valid signed vote");
 
     let mut invalid_vote = vote;
     invalid_vote.proposal_id = unknown_proposal_id;
@@ -1024,7 +1093,7 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_rejects_unknown_session() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
 
     let err = service
@@ -1040,7 +1109,7 @@ async fn test_handle_consensus_timeout_rejects_unknown_session() {
 
 #[tokio::test]
 async fn test_process_incoming_proposal_rejects_expired_proposal() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1070,7 +1139,7 @@ async fn test_process_incoming_proposal_rejects_expired_proposal() {
 
 #[tokio::test]
 async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1091,13 +1160,18 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote should succeed");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
         .await
         .expect("valid vote should be built");
     vote.vote_hash = vec![1; 32];
@@ -1115,7 +1189,7 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
 
 #[tokio::test]
 async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1136,18 +1210,18 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(
-            &scope,
-            proposal.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner.clone()),
-        )
-        .await
-        .expect("first vote should succeed");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner.clone()),
+    )
+    .await
+    .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
         .await
         .expect("valid vote should be built");
     let wrong_signer = PrivateKeySigner::random();
@@ -1171,7 +1245,7 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
 
 #[tokio::test]
 async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1192,17 +1266,17 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(
-            &scope,
-            proposal.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner.clone()),
-        )
-        .await
-        .expect("first owner vote should succeed");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner.clone()),
+    )
+    .await
+    .expect("first owner vote should succeed");
 
-    let duplicate_vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
+    let duplicate_vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
         .await
         .expect("duplicate vote should be signable");
 
@@ -1219,7 +1293,7 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
 
 #[tokio::test]
 async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1240,13 +1314,18 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote should succeed");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
         .await
         .expect("valid vote should be built");
     vote.timestamp = proposal.expiration_timestamp.saturating_add(1);
@@ -1273,7 +1352,7 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1295,16 +1374,26 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
         .await
         .expect("proposal should be created");
 
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote should succeed");
 
     let voter2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote should succeed");
 
     let err_first = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
@@ -1333,7 +1422,7 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
 
 #[tokio::test]
 async fn test_handle_consensus_timeout_rejects_unknown_scope() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let unknown_scope = ScopeID::from("unknown_scope");
 
     let err = service
@@ -1349,7 +1438,7 @@ async fn test_handle_consensus_timeout_rejects_unknown_scope() {
 
 #[tokio::test]
 async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let mut events = service.event_bus().subscribe();
     let scope = ScopeID::from("still_active_no_event_scope");
     let proposal_owner = PrivateKeySigner::random();
@@ -1365,10 +1454,15 @@ async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
     .await;
 
     // One vote is insufficient for n=4; transition should remain StillActive.
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should succeed");
 
     let no_event = timeout(Duration::from_millis(150), events.recv()).await;
     assert!(
@@ -1380,7 +1474,7 @@ async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
 #[tokio::test]
 async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_expiration_not_after_timestamp()
  {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("resolve_config_base_timeout_scope");
 
     let request = CreateProposalRequest::new(
@@ -1429,7 +1523,7 @@ async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_ex
 
 #[tokio::test]
 async fn test_get_reached_proposals_with_consensus() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1452,10 +1546,15 @@ async fn test_get_reached_proposals_with_consensus() {
         .expect("proposal should be created");
 
     // Cast vote to reach consensus
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should succeed");
 
     // Get reached proposals
     let reached_map = service
@@ -1482,7 +1581,7 @@ async fn test_get_reached_proposals_with_consensus() {
 
 #[tokio::test]
 async fn test_get_reached_proposals_no_consensus() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1521,7 +1620,7 @@ async fn test_get_reached_proposals_no_consensus() {
 
 #[tokio::test]
 async fn test_get_reached_proposals_mixed_states() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner1 = PrivateKeySigner::random();
     let proposal_owner2 = PrivateKeySigner::random();
@@ -1545,10 +1644,15 @@ async fn test_get_reached_proposals_mixed_states() {
         .await
         .expect("proposal should be created");
 
-    service
-        .cast_vote(&scope, proposal1.proposal_id, true, wrap(proposal_owner1))
-        .await
-        .expect("vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal1.proposal_id,
+        true,
+        &wrap(proposal_owner1),
+    )
+    .await
+    .expect("vote should succeed");
 
     // Create proposal 2 that reaches consensus (NO)
     let proposal2 = service
@@ -1568,10 +1672,15 @@ async fn test_get_reached_proposals_mixed_states() {
         .await
         .expect("proposal should be created");
 
-    service
-        .cast_vote(&scope, proposal2.proposal_id, false, wrap(proposal_owner2))
-        .await
-        .expect("vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal2.proposal_id,
+        false,
+        &wrap(proposal_owner2),
+    )
+    .await
+    .expect("vote should succeed");
 
     // Create proposal 3 that remains active (doesn't reach consensus)
     let proposal3 = service
@@ -1631,7 +1740,7 @@ async fn test_get_reached_proposals_mixed_states() {
 
 #[tokio::test]
 async fn test_get_reached_proposals_nonexistent_scope() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let nonexistent_scope = ScopeID::from("nonexistent");
 
     // Get reached proposals for non-existent scope
@@ -1649,7 +1758,7 @@ async fn test_get_reached_proposals_nonexistent_scope() {
 
 #[tokio::test]
 async fn test_unknown_scope_queries_stats_and_active_proposals() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let unknown_scope = ScopeID::from("unknown_scope");
 
     let stats = service.get_scope_stats(&unknown_scope).await;
@@ -1683,7 +1792,7 @@ async fn test_unknown_scope_queries_stats_and_active_proposals() {
 
 #[tokio::test]
 async fn test_delete_scope_cleans_up_all_state() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("delete_scope_test");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1698,10 +1807,15 @@ async fn test_delete_scope_cleans_up_all_state() {
     )
     .await;
 
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should succeed");
 
     // Verify state exists
     let consensus_result = service
@@ -1771,10 +1885,15 @@ async fn test_delete_scope_cleans_up_all_state() {
     )
     .await;
 
-    service
-        .cast_vote(&scope, new_proposal.proposal_id, VOTE_YES, wrap(new_owner))
-        .await
-        .expect("vote on new proposal should succeed");
+    cast_remote_vote(
+        &service,
+        &scope,
+        new_proposal.proposal_id,
+        VOTE_YES,
+        &wrap(new_owner),
+    )
+    .await
+    .expect("vote on new proposal should succeed");
 
     let new_result = service
         .storage()
@@ -1786,7 +1905,7 @@ async fn test_delete_scope_cleans_up_all_state() {
 
 #[tokio::test]
 async fn test_delete_scope_on_unknown_scope_is_ok() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let unknown_scope = ScopeID::from("never_existed");
 
     // Deleting a scope that was never created should not error

--- a/tests/custom_scheme_tests.rs
+++ b/tests/custom_scheme_tests.rs
@@ -15,6 +15,7 @@ use hashgraph_like_consensus::{
     signing::{ConsensusSchemeError, ConsensusSignatureScheme},
     storage::{ConsensusStorage, InMemoryConsensusStorage},
     types::CreateProposalRequest,
+    utils::build_vote,
 };
 use sha2::{Digest, Sha256};
 
@@ -74,26 +75,32 @@ type StubService = ConsensusService<
     StubSigner,
 >;
 
+/// Build a per-peer service sharing storage and event bus.
+fn peer_service(
+    storage: &InMemoryConsensusStorage<ScopeID>,
+    bus: &BroadcastEventBus<ScopeID>,
+    signer: StubSigner,
+) -> StubService {
+    StubService::new_with_components(storage.clone(), bus.clone(), signer, 10)
+}
+
 #[tokio::test]
 async fn stub_scheme_reaches_consensus_without_ethereum_types() {
-    let service: StubService = StubService::new_with_components(
-        InMemoryConsensusStorage::new(),
-        BroadcastEventBus::default(),
-        10,
-    );
+    let storage = InMemoryConsensusStorage::<ScopeID>::new();
+    let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from("stub-scope");
 
-    let owner = StubSigner::new([1; STUB_IDENTITY_LEN]);
-    let voter_two = StubSigner::new([2; STUB_IDENTITY_LEN]);
-    let voter_three = StubSigner::new([3; STUB_IDENTITY_LEN]);
+    let owner = peer_service(&storage, &bus, StubSigner::new([1; STUB_IDENTITY_LEN]));
+    let voter_two = peer_service(&storage, &bus, StubSigner::new([2; STUB_IDENTITY_LEN]));
+    let voter_three = peer_service(&storage, &bus, StubSigner::new([3; STUB_IDENTITY_LEN]));
 
-    let proposal = service
+    let proposal = owner
         .create_proposal_with_config(
             &scope,
             CreateProposalRequest::new(
                 "stub-proposal".into(),
                 b"payload".to_vec(),
-                owner.identity().to_vec(),
+                owner.signer().identity().to_vec(),
                 3,
                 60,
                 true,
@@ -104,20 +111,20 @@ async fn stub_scheme_reaches_consensus_without_ethereum_types() {
         .await
         .expect("proposal should be created");
 
-    service
-        .cast_vote(&scope, proposal.proposal_id, true, owner)
+    owner
+        .cast_vote(&scope, proposal.proposal_id, true)
         .await
         .expect("owner vote");
-    service
-        .cast_vote(&scope, proposal.proposal_id, true, voter_two)
+    voter_two
+        .cast_vote(&scope, proposal.proposal_id, true)
         .await
         .expect("voter two");
-    service
-        .cast_vote(&scope, proposal.proposal_id, true, voter_three)
+    voter_three
+        .cast_vote(&scope, proposal.proposal_id, true)
         .await
         .expect("voter three");
 
-    let session = service
+    let session = owner
         .storage()
         .get_session(&scope, proposal.proposal_id)
         .await
@@ -131,23 +138,20 @@ async fn stub_scheme_reaches_consensus_without_ethereum_types() {
 
 #[tokio::test]
 async fn stub_scheme_rejects_forged_signature() {
-    let service: StubService = StubService::new_with_components(
-        InMemoryConsensusStorage::new(),
-        BroadcastEventBus::default(),
-        10,
-    );
+    let storage = InMemoryConsensusStorage::<ScopeID>::new();
+    let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from("stub-scope-forge");
 
-    let owner = StubSigner::new([9; STUB_IDENTITY_LEN]);
+    let owner = peer_service(&storage, &bus, StubSigner::new([9; STUB_IDENTITY_LEN]));
     let voter = StubSigner::new([10; STUB_IDENTITY_LEN]);
 
-    let proposal = service
+    let proposal = owner
         .create_proposal_with_config(
             &scope,
             CreateProposalRequest::new(
                 "stub-proposal".into(),
                 b"payload".to_vec(),
-                owner.identity().to_vec(),
+                owner.signer().identity().to_vec(),
                 2,
                 60,
                 true,
@@ -158,13 +162,11 @@ async fn stub_scheme_rejects_forged_signature() {
         .await
         .expect("proposal should be created");
 
-    let mut vote = hashgraph_like_consensus::utils::build_vote(&proposal, true, voter.clone())
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, true, &voter).await.expect("vote");
     // Tamper with the signature so verify() returns false.
     vote.signature.iter_mut().for_each(|b| *b ^= 0xFF);
 
-    let err = service
+    let err = owner
         .process_incoming_vote(&scope, vote)
         .await
         .expect_err("forged signature must be rejected");

--- a/tests/network_gossip_tests.rs
+++ b/tests/network_gossip_tests.rs
@@ -4,8 +4,28 @@ use tokio::time::{Duration, sleep};
 use hashgraph_like_consensus::{
     error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
     session::ConsensusConfig, signing::EthereumConsensusSigner, storage::ConsensusStorage,
-    types::CreateProposalRequest,
+    types::CreateProposalRequest, utils::build_vote,
 };
+
+async fn cast_remote_vote(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Vote,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
+    let vote = build_vote(&proposal, choice, signer).await?;
+    service.process_incoming_vote(scope, vote.clone()).await?;
+    Ok(vote)
+}
+
+fn make_service() -> DefaultConsensusService {
+    DefaultConsensusService::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
+}
 
 fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
     EthereumConsensusSigner::new(signer)
@@ -24,8 +44,8 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
 /// gossip votes back/forth, and both peers converge to Ok(true) consensus result.
 #[tokio::test]
 async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
-    let peer_a = DefaultConsensusService::default();
-    let peer_b = DefaultConsensusService::default();
+    let peer_a = make_service();
+    let peer_b = make_service();
     let scope = ScopeID::from(SCOPE);
 
     let owner_a = PrivateKeySigner::random();
@@ -53,8 +73,7 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
         .expect("peer_b accepts proposal");
 
     // Peer A votes YES, gossip vote to peer B.
-    let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
+    let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
         .await
         .expect("peer_a vote");
     peer_b
@@ -64,8 +83,7 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
 
     // Peer B votes YES, gossip vote to peer A.
     let owner_b = PrivateKeySigner::random();
-    let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_b))
+    let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(owner_b))
         .await
         .expect("peer_b vote");
     peer_a
@@ -93,9 +111,9 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
 /// but still converges to the same YES result.
 #[tokio::test]
 async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
-    let peer_a = DefaultConsensusService::default();
-    let peer_b = DefaultConsensusService::default();
-    let peer_c = DefaultConsensusService::default();
+    let peer_a = make_service();
+    let peer_b = make_service();
+    let peer_c = make_service();
     let scope = ScopeID::from(format!("{SCOPE}_3p"));
 
     let owner_a = PrivateKeySigner::random();
@@ -127,13 +145,11 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
         .expect("peer_c accepts proposal");
 
     // Two YES votes are sufficient for n=3 with threshold 2/3 and majority YES.
-    let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
+    let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
         .await
         .expect("peer_a vote");
     let owner_b = PrivateKeySigner::random();
-    let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_b))
+    let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(owner_b))
         .await
         .expect("peer_b vote");
 
@@ -184,9 +200,9 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
 /// resulting in a 2 YES / 2 NO tie → no consensus.
 #[tokio::test]
 async fn test_multi_peer_timeout_task_converges_to_failed() {
-    let peer_a = DefaultConsensusService::default();
-    let peer_b = DefaultConsensusService::default();
-    let peer_c = DefaultConsensusService::default();
+    let peer_a = make_service();
+    let peer_b = make_service();
+    let peer_c = make_service();
     let scope = ScopeID::from(format!("{SCOPE}_timeout"));
 
     // n=4, liveness=false, 2 YES votes → 2 YES + 2 silent(NO) = tied → fail.
@@ -219,8 +235,7 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
         .expect("peer_c accepts proposal");
 
     // 2 YES votes total.
-    let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
+    let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
         .await
         .expect("peer_a vote");
     peer_b
@@ -232,8 +247,7 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
         .await
         .expect("peer_c accepts vote_a");
 
-    let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(voter_b))
+    let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(voter_b))
         .await
         .expect("peer_b vote");
     peer_a
@@ -309,10 +323,10 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
 /// Result depends on the liveness criteria as we have 2 YES and 2 NO votes.
 #[tokio::test]
 async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
-    let peer_a = DefaultConsensusService::default();
-    let peer_b = DefaultConsensusService::default();
-    let peer_c = DefaultConsensusService::default();
-    let peer_d = DefaultConsensusService::default();
+    let peer_a = make_service();
+    let peer_b = make_service();
+    let peer_c = make_service();
+    let peer_d = make_service();
     let scope = ScopeID::from(format!("{SCOPE}_timeout_tie"));
 
     // n=4, votes: 2 YES / 2 NO => tie. With liveness_criteria_yes=true, resolve to YES.
@@ -342,8 +356,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
 
     // Cast votes sequentially, gossiping each vote to all peers before the next voter votes,
     // so that received_hash references match on every peer.
-    let vote_a = peer_a
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(owner_a))
+    let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
         .await
         .expect("vote_a");
     for peer in [&peer_b, &peer_c, &peer_d] {
@@ -353,8 +366,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     }
 
     let voter_b = PrivateKeySigner::random();
-    let vote_b = peer_b
-        .cast_vote(&scope, proposal.proposal_id, true, wrap(voter_b))
+    let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(voter_b))
         .await
         .expect("vote_b");
     for peer in [&peer_a, &peer_c, &peer_d] {
@@ -364,8 +376,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     }
 
     let voter_c = PrivateKeySigner::random();
-    let vote_c = peer_c
-        .cast_vote(&scope, proposal.proposal_id, false, wrap(voter_c))
+    let vote_c = cast_remote_vote(&peer_c, &scope, proposal.proposal_id, false, &wrap(voter_c))
         .await
         .expect("vote_c");
     for peer in [&peer_a, &peer_b, &peer_d] {
@@ -375,8 +386,7 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     }
 
     let voter_d = PrivateKeySigner::random();
-    let vote_d = peer_d
-        .cast_vote(&scope, proposal.proposal_id, false, wrap(voter_d))
+    let vote_d = cast_remote_vote(&peer_d, &scope, proposal.proposal_id, false, &wrap(voter_d))
         .await
         .expect("vote_d");
     for peer in [&peer_a, &peer_b, &peer_c] {

--- a/tests/rfc_compliance_tests.rs
+++ b/tests/rfc_compliance_tests.rs
@@ -14,6 +14,40 @@ use hashgraph_like_consensus::{
     utils::{build_vote, compute_vote_hash},
 };
 
+async fn cast_remote_vote(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Vote,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
+    let vote = build_vote(&proposal, choice, signer).await?;
+    service.process_incoming_vote(scope, vote.clone()).await?;
+    Ok(vote)
+}
+
+async fn cast_remote_vote_and_get_proposal(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Proposal,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
+    service.storage().get_proposal(scope, proposal_id).await
+}
+
+fn make_service() -> DefaultConsensusService {
+    DefaultConsensusService::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
+}
+
 fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
     EthereumConsensusSigner::new(signer)
 }
@@ -43,7 +77,7 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
 /// Test that proposal initialization has round = 1
 #[tokio::test]
 async fn test_proposal_initialization_round_is_one() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -70,7 +104,7 @@ async fn test_proposal_initialization_round_is_one() {
 /// RFC Section 2.5.3: Test that round increments when votes are added (P2P mode)
 #[tokio::test]
 async fn test_round_increments_on_vote_p2p() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -96,10 +130,15 @@ async fn test_round_increments_on_vote_p2p() {
         "P2P: Proposal should start with round = 1"
     );
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should be added");
 
     assert_eq!(
         proposal.round, 2,
@@ -107,10 +146,15 @@ async fn test_round_increments_on_vote_p2p() {
     );
 
     let voter2 = PrivateKeySigner::random();
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote should be added");
 
     assert_eq!(
         proposal.round, 3,
@@ -121,7 +165,7 @@ async fn test_round_increments_on_vote_p2p() {
 /// RFC Section 2.5.3: Test that gossipsub keeps rounds at 2 for all votes
 #[tokio::test]
 async fn test_gossipsub_rounds_stay_at_two() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -150,10 +194,15 @@ async fn test_gossipsub_rounds_stay_at_two() {
     );
 
     // First vote moves to round 2
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should be added");
 
     assert_eq!(
         proposal.round, 2,
@@ -163,10 +212,15 @@ async fn test_gossipsub_rounds_stay_at_two() {
 
     // Second vote stays at round 2
     let voter2 = PrivateKeySigner::random();
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote should be added");
 
     assert_eq!(
         proposal.round, 2,
@@ -176,10 +230,15 @@ async fn test_gossipsub_rounds_stay_at_two() {
 
     // Third vote also stays at round 2 (this reaches consensus with 3 YES votes)
     let voter3 = PrivateKeySigner::random();
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter3))
-        .await
-        .expect("third vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter3),
+    )
+    .await
+    .expect("third vote should be added");
 
     assert_eq!(
         proposal.round, 2,
@@ -195,7 +254,7 @@ async fn test_gossipsub_rounds_stay_at_two() {
 /// Test that gossipsub allows multiple votes in round 2 (not limited to 2 votes)
 #[tokio::test]
 async fn test_gossipsub_allows_multiple_votes_in_round_two() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -221,10 +280,15 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
         .expect("proposal should be created");
 
     // First vote moves to round 2
-    let mut last_proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should be added");
+    let mut last_proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should be added");
     assert_eq!(last_proposal.round, 2);
     assert_eq!(last_proposal.votes.len(), 1);
 
@@ -232,10 +296,15 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
     // With 7 YES votes out of 12, we have >6 YES votes, so consensus is reached
     for i in 0..6 {
         let voter = PrivateKeySigner::random();
-        last_proposal = service
-            .cast_vote_and_get_proposal(&scope, last_proposal.proposal_id, VOTE_YES, wrap(voter))
-            .await
-            .unwrap_or_else(|_| panic!("vote {} should be added", i + 2));
+        last_proposal = cast_remote_vote_and_get_proposal(
+            &service,
+            &scope,
+            last_proposal.proposal_id,
+            VOTE_YES,
+            &wrap(voter),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("vote {} should be added", i + 2));
         assert_eq!(
             last_proposal.round, 2,
             "Gossipsub: All votes should stay in round 2"
@@ -256,7 +325,7 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
 /// Test that P2P mode uses ceil(2n/3) for max rounds when max_rounds = 0
 #[tokio::test]
 async fn test_p2p_dynamic_max_rounds() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -286,15 +355,15 @@ async fn test_p2p_dynamic_max_rounds() {
 
     let mut last_proposal = proposal;
     for (i, voter) in voters.iter().enumerate() {
-        last_proposal = service
-            .cast_vote_and_get_proposal(
-                &scope,
-                last_proposal.proposal_id,
-                VOTE_YES,
-                wrap(voter.clone()),
-            )
-            .await
-            .unwrap_or_else(|_| panic!("vote {} should be added", i + 1));
+        last_proposal = cast_remote_vote_and_get_proposal(
+            &service,
+            &scope,
+            last_proposal.proposal_id,
+            VOTE_YES,
+            &wrap(voter.clone()),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("vote {} should be added", i + 1));
         assert_eq!(
             last_proposal.round,
             (i + 2) as u32,
@@ -334,7 +403,7 @@ async fn test_p2p_dynamic_max_rounds() {
 /// Test P2P ceil(2n/3) calculation for various values of n
 #[tokio::test]
 async fn test_p2p_ceil_calculation_edge_cases() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
 
     // Test various values of n to verify ceil(2n/3) calculation
@@ -378,15 +447,15 @@ async fn test_p2p_ceil_calculation_edge_cases() {
 
         let mut last_proposal = proposal;
         for (i, voter) in voters.iter().enumerate() {
-            last_proposal = service
-                .cast_vote_and_get_proposal(
-                    &scope,
-                    last_proposal.proposal_id,
-                    VOTE_YES,
-                    wrap(voter.clone()),
-                )
-                .await
-                .unwrap_or_else(|_| panic!("vote {} for n={} should succeed", i + 1, n));
+            last_proposal = cast_remote_vote_and_get_proposal(
+                &service,
+                &scope,
+                last_proposal.proposal_id,
+                VOTE_YES,
+                &wrap(voter.clone()),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("vote {} for n={} should succeed", i + 1, n));
         }
 
         assert_eq!(
@@ -402,7 +471,7 @@ async fn test_p2p_ceil_calculation_edge_cases() {
 /// Test that gossipsub correctly processes batch votes via process_incoming_proposal
 #[tokio::test]
 async fn test_gossipsub_batch_vote_processing() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("batch_gossipsub");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -421,21 +490,21 @@ async fn test_gossipsub_batch_vote_processing() {
 
     // Add votes to the proposal (simulating votes received from network)
     let voter1 = PrivateKeySigner::random();
-    let vote1 = build_vote(&proposal, VOTE_YES, wrap(voter1))
+    let vote1 = build_vote(&proposal, VOTE_YES, &wrap(voter1))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote1);
     proposal.round = 2; // Gossipsub: round 2 after first vote
 
     let voter2 = PrivateKeySigner::random();
-    let vote2 = build_vote(&proposal, VOTE_YES, wrap(voter2))
+    let vote2 = build_vote(&proposal, VOTE_YES, &wrap(voter2))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote2);
     // Round stays at 2 for gossipsub
 
     let voter3 = PrivateKeySigner::random();
-    let vote3 = build_vote(&proposal, VOTE_YES, wrap(voter3))
+    let vote3 = build_vote(&proposal, VOTE_YES, &wrap(voter3))
         .await
         .expect("vote should be created");
     proposal.votes.push(vote3);
@@ -452,10 +521,15 @@ async fn test_gossipsub_batch_vote_processing() {
 
     // Verify by casting another vote and checking the proposal
     let voter4 = PrivateKeySigner::random();
-    let final_proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(voter4))
-        .await
-        .expect("additional vote should succeed");
+    let final_proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter4),
+    )
+    .await
+    .expect("additional vote should succeed");
     assert_eq!(
         final_proposal.round, 2,
         "Gossipsub: Round should be 2 after batch processing"
@@ -470,7 +544,7 @@ async fn test_gossipsub_batch_vote_processing() {
 /// Test that P2P correctly processes batch votes via process_incoming_proposal
 #[tokio::test]
 async fn test_p2p_batch_vote_processing() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("batch_p2p");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -494,7 +568,7 @@ async fn test_p2p_batch_vote_processing() {
     }
 
     for (i, voter) in voters.iter().enumerate() {
-        let vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
+        let vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
             .await
             .expect("vote should be created");
         proposal.votes.push(vote);
@@ -527,9 +601,14 @@ async fn test_p2p_batch_vote_processing() {
     // Verify that consensus prevents further votes (session is no longer active)
     // Try to add one more vote - should fail because consensus is already reached
     let voter7 = PrivateKeySigner::random();
-    let _vote_result = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter7))
-        .await;
+    let _vote_result = cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter7),
+    )
+    .await;
 
     // The vote might succeed (returns vote) but won't be added because session reached consensus
     // Or it might fail with SessionNotActive
@@ -554,7 +633,7 @@ async fn test_p2p_batch_vote_processing() {
 /// Test that consensus can be reached in both modes
 #[tokio::test]
 async fn test_consensus_reachable_in_both_modes() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
 
     // Test gossipsub mode
     let scope1 = ScopeID::from("gossipsub_consensus");
@@ -583,10 +662,15 @@ async fn test_consensus_reachable_in_both_modes() {
     }
 
     for voter in voters1 {
-        service
-            .cast_vote(&scope1, proposal1.proposal_id, VOTE_YES, wrap(voter))
-            .await
-            .expect("vote should succeed");
+        cast_remote_vote(
+            &service,
+            &scope1,
+            proposal1.proposal_id,
+            VOTE_YES,
+            &wrap(voter),
+        )
+        .await
+        .expect("vote should succeed");
     }
 
     let result1 = service
@@ -623,10 +707,15 @@ async fn test_consensus_reachable_in_both_modes() {
     }
 
     for voter in voters2 {
-        service
-            .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter))
-            .await
-            .expect("vote should succeed");
+        cast_remote_vote(
+            &service,
+            &scope2,
+            proposal2.proposal_id,
+            VOTE_YES,
+            &wrap(voter),
+        )
+        .await
+        .expect("vote should succeed");
     }
 
     let result2 = service
@@ -640,7 +729,7 @@ async fn test_consensus_reachable_in_both_modes() {
 /// RFC Section 4: Test that n ≤ 2 requires unanimous YES votes
 #[tokio::test]
 async fn test_n_le_2_requires_unanimous_yes() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -661,10 +750,15 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("vote should be added");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("vote should be added");
 
     // Should reach consensus immediately with unanimous YES
     let result = service
@@ -694,21 +788,26 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .await
         .expect("proposal should be created");
 
-    let proposal2 = service
-        .cast_vote_and_get_proposal(
-            &scope2,
-            proposal2.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner2),
-        )
-        .await
-        .expect("first vote");
+    let proposal2 = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner2),
+    )
+    .await
+    .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote");
+    cast_remote_vote(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
     let result = service
@@ -738,21 +837,26 @@ async fn test_n_le_2_requires_unanimous_yes() {
         .await
         .expect("proposal should be created");
 
-    let proposal3 = service
-        .cast_vote_and_get_proposal(
-            &scope3,
-            proposal3.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner3),
-        )
-        .await
-        .expect("first vote");
+    let proposal3 = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope3,
+        proposal3.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner3),
+    )
+    .await
+    .expect("first vote");
 
     let voter3 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope3, proposal3.proposal_id, VOTE_NO, wrap(voter3))
-        .await
-        .expect("second vote");
+    cast_remote_vote(
+        &service,
+        &scope3,
+        proposal3.proposal_id,
+        VOTE_NO,
+        &wrap(voter3),
+    )
+    .await
+    .expect("second vote");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
     let result = service
@@ -772,7 +876,7 @@ async fn test_n_le_2_requires_unanimous_yes() {
 /// RFC Section 4: Test that n > 2 requires more than n/2 YES votes among 2n/3 distinct peers
 #[tokio::test]
 async fn test_n_gt_2_consensus_requirements() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -793,10 +897,15 @@ async fn test_n_gt_2_consensus_requirements() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote");
 
     // Only 1 YES vote, not enough (need 2)
     let result = service
@@ -813,10 +922,15 @@ async fn test_n_gt_2_consensus_requirements() {
     );
 
     let voter2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
     let result = service
@@ -836,7 +950,7 @@ async fn test_n_gt_2_consensus_requirements() {
 /// RFC Section 2.5.4: Test that expired proposals are rejected
 #[tokio::test]
 async fn test_expired_proposal_rejected() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -859,21 +973,33 @@ async fn test_expired_proposal_rejected() {
 
     sleep(Duration::from_secs(EXPIRATION_WAIT_TIME_2_SECOND)).await;
     let voter = PrivateKeySigner::random();
-    let err = service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter))
-        .await
-        .expect_err("Should reject vote on expired proposal");
+    let err = cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter),
+    )
+    .await
+    .expect_err("Should reject vote on expired proposal");
 
+    // process_incoming_vote rejects via validate_vote (VoteExpired) when the
+    // current timestamp is past expiration; the direct cast_vote path would
+    // raise ProposalExpired in validate_proposal_timestamp first. Either is
+    // acceptable per RFC 2.5.4.
     assert!(
-        matches!(err, ConsensusError::ProposalExpired),
-        "RFC Section 2.5.4: Should reject votes on expired proposals"
+        matches!(
+            err,
+            ConsensusError::ProposalExpired | ConsensusError::VoteExpired
+        ),
+        "RFC Section 2.5.4: Should reject votes on expired proposals, got {err:?}"
     );
 }
 
 /// RFC Section 3.4: Test timestamp replay attack protection
 #[tokio::test]
 async fn test_timestamp_replay_attack_protection() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -894,10 +1020,15 @@ async fn test_timestamp_replay_attack_protection() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote");
 
     // Create a vote with old timestamp (more than 1 hour ago)
     let old_timestamp = SystemTime::now()
@@ -907,7 +1038,7 @@ async fn test_timestamp_replay_attack_protection() {
         .saturating_sub(EXPIRATION * 2); // More than expiration time
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter.clone()))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
         .await
         .expect("create vote");
 
@@ -937,7 +1068,7 @@ async fn test_timestamp_replay_attack_protection() {
 /// RFC Section 4: Test equality of votes handling
 #[tokio::test]
 async fn test_equality_of_votes_handling() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -961,28 +1092,48 @@ async fn test_equality_of_votes_handling() {
         .await
         .expect("proposal should be created");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("first vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_YES, wrap(voter2))
-        .await
-        .expect("second vote");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(voter2),
+    )
+    .await
+    .expect("second vote");
 
     let voter3 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, wrap(voter3))
-        .await
-        .expect("third vote");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_NO,
+        &wrap(voter3),
+    )
+    .await
+    .expect("third vote");
 
     let voter4 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope, proposal.proposal_id, VOTE_NO, wrap(voter4))
-        .await
-        .expect("fourth vote");
+    cast_remote_vote(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_NO,
+        &wrap(voter4),
+    )
+    .await
+    .expect("fourth vote");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
     // We have 4 votes: 2 YES, 2 NO (equality)
@@ -1021,33 +1172,48 @@ async fn test_equality_of_votes_handling() {
         .await
         .expect("proposal should be created");
 
-    let proposal2 = service
-        .cast_vote_and_get_proposal(
-            &scope2,
-            proposal2.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner2),
-        )
-        .await
-        .expect("first vote");
+    let proposal2 = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner2),
+    )
+    .await
+    .expect("first vote");
 
     let voter2_2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_YES, wrap(voter2_2))
-        .await
-        .expect("second vote");
+    cast_remote_vote(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_YES,
+        &wrap(voter2_2),
+    )
+    .await
+    .expect("second vote");
 
     let voter3_2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, wrap(voter3_2))
-        .await
-        .expect("third vote");
+    cast_remote_vote(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_NO,
+        &wrap(voter3_2),
+    )
+    .await
+    .expect("third vote");
 
     let voter4_2 = PrivateKeySigner::random();
-    service
-        .cast_vote(&scope2, proposal2.proposal_id, VOTE_NO, wrap(voter4_2))
-        .await
-        .expect("fourth vote");
+    cast_remote_vote(
+        &service,
+        &scope2,
+        proposal2.proposal_id,
+        VOTE_NO,
+        &wrap(voter4_2),
+    )
+    .await
+    .expect("fourth vote");
 
     sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
     // Equality with liveness_criteria_yes = false should resolve to NO

--- a/tests/scope_config_tests.rs
+++ b/tests/scope_config_tests.rs
@@ -1,10 +1,15 @@
 use std::time::Duration;
 
+use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::{
     error::ConsensusError, scope::ScopeID, scope_config::NetworkType,
-    service::DefaultConsensusService, session::ConsensusConfig, storage::ConsensusStorage,
-    types::CreateProposalRequest,
+    service::DefaultConsensusService, session::ConsensusConfig, signing::EthereumConsensusSigner,
+    storage::ConsensusStorage, types::CreateProposalRequest,
 };
+
+fn make_service() -> DefaultConsensusService {
+    DefaultConsensusService::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
+}
 
 const SCOPE_NAME: &str = "test_scope";
 const PROPOSAL_PAYLOAD: Vec<u8> = vec![];
@@ -14,7 +19,7 @@ const DEFAULT_SHORT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[tokio::test]
 async fn test_scope_config_creation() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE_NAME);
 
     // Initialize scope with P2P network and custom threshold
@@ -41,7 +46,7 @@ async fn test_scope_config_creation() {
 
 #[tokio::test]
 async fn test_scope_config_update() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("update_test_scope");
 
     // Initialize with default config
@@ -76,7 +81,7 @@ async fn test_scope_config_update() {
 
 #[tokio::test]
 async fn test_scope_config_update_multiple_fields() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("multi_update_scope");
 
     // Initialize with initial config
@@ -114,7 +119,7 @@ async fn test_scope_config_update_multiple_fields() {
 
 #[tokio::test]
 async fn test_scope_config_presets() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("preset_test_scope");
 
     // Test P2P preset
@@ -150,7 +155,7 @@ async fn test_scope_config_presets() {
 
 #[tokio::test]
 async fn test_scope_config_validation() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("validation_test_scope");
 
     // Test invalid threshold (too high)
@@ -197,7 +202,7 @@ async fn test_scope_config_validation() {
 
 #[tokio::test]
 async fn test_scope_config_new_scope_uses_defaults() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("new_scope_defaults");
 
     // Get config for non-existent scope - should return defaults
@@ -212,7 +217,7 @@ async fn test_scope_config_new_scope_uses_defaults() {
 
 #[tokio::test]
 async fn test_max_rounds_override_zero_validation() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope_p2p = ScopeID::from("p2p_zero_rounds");
     let scope_gossipsub = ScopeID::from("gossipsub_zero_rounds");
 
@@ -258,7 +263,7 @@ async fn test_max_rounds_override_zero_validation() {
 
 #[tokio::test]
 async fn create_proposal_with_config_preserves_override_timeout() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("test_scope");
 
     let request = CreateProposalRequest::new(
@@ -291,7 +296,7 @@ async fn create_proposal_with_config_preserves_override_timeout() {
 
 #[tokio::test]
 async fn test_scope_config_convenience_profiles_and_network_defaults() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("convenience_profiles_scope");
 
     // Ensure strict profile is applied and persists through initialize.
@@ -349,7 +354,7 @@ async fn test_scope_config_convenience_profiles_and_network_defaults() {
 
 #[tokio::test]
 async fn test_scope_config_update_replaces_all_fields() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from("replace_all_fields_scope");
 
     // Initialize with P2P defaults

--- a/tests/vote_tests.rs
+++ b/tests/vote_tests.rs
@@ -4,7 +4,7 @@ use hashgraph_like_consensus::{
     scope::ScopeID,
     service::DefaultConsensusService,
     session::ConsensusConfig,
-    signing::EthereumConsensusSigner,
+    signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
     types::CreateProposalRequest,
     utils::{build_vote, validate_proposal},
 };
@@ -23,15 +23,11 @@ const EXPECTED_VOTERS_COUNT: u32 = 3;
 const VOTE_YES: bool = true;
 const VOTE_NO: bool = false;
 
-fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
-    signer.address().as_slice().to_vec()
-}
-
 #[tokio::test]
 async fn test_received_hash_for_new_voter() {
-    let service = DefaultConsensusService::default();
+    let proposal_owner = wrap(PrivateKeySigner::random());
+    let service = DefaultConsensusService::new(proposal_owner.clone());
     let scope = ScopeID::from(SCOPE);
-    let proposal_owner = PrivateKeySigner::random();
 
     let proposal = service
         .create_proposal_with_config(
@@ -39,7 +35,7 @@ async fn test_received_hash_for_new_voter() {
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
                 PROPOSAL_PAYLOAD,
-                owner_bytes(&proposal_owner),
+                proposal_owner.identity().to_vec(),
                 EXPECTED_VOTERS_COUNT,
                 EXPIRATION,
                 true,
@@ -51,12 +47,12 @@ async fn test_received_hash_for_new_voter() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES)
         .await
         .expect("proposal_owner vote");
 
-    let other_voter = PrivateKeySigner::random();
-    let vote = build_vote(&proposal, VOTE_YES, wrap(other_voter))
+    let other_voter = wrap(PrivateKeySigner::random());
+    let vote = build_vote(&proposal, VOTE_YES, &other_voter)
         .await
         .expect("second vote");
 
@@ -77,9 +73,9 @@ async fn test_received_hash_for_new_voter() {
 
 #[tokio::test]
 async fn test_parent_hash_for_same_voter() {
-    let service = DefaultConsensusService::default();
+    let proposal_owner = wrap(PrivateKeySigner::random());
+    let service = DefaultConsensusService::new(proposal_owner.clone());
     let scope = ScopeID::from(SCOPE);
-    let proposal_owner = PrivateKeySigner::random();
 
     let proposal = service
         .create_proposal_with_config(
@@ -87,7 +83,7 @@ async fn test_parent_hash_for_same_voter() {
             CreateProposalRequest::new(
                 PROPOSAL_NAME.to_string(),
                 PROPOSAL_PAYLOAD,
-                owner_bytes(&proposal_owner),
+                proposal_owner.identity().to_vec(),
                 EXPECTED_VOTERS_COUNT,
                 EXPIRATION,
                 true,
@@ -99,17 +95,12 @@ async fn test_parent_hash_for_same_voter() {
         .expect("proposal");
 
     let proposal = service
-        .cast_vote_and_get_proposal(
-            &scope,
-            proposal.proposal_id,
-            VOTE_YES,
-            wrap(proposal_owner.clone()),
-        )
+        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES)
         .await
         .expect("proposal_owner vote");
 
     // Create a second vote from the same voter to exercise parent_hash logic.
-    let second_vote = build_vote(&proposal, VOTE_NO, wrap(proposal_owner))
+    let second_vote = build_vote(&proposal, VOTE_NO, &proposal_owner)
         .await
         .expect("second vote");
 

--- a/tests/vote_validation_tests.rs
+++ b/tests/vote_validation_tests.rs
@@ -8,9 +8,44 @@ use hashgraph_like_consensus::{
     scope::ScopeID,
     service::DefaultConsensusService,
     session::ConsensusConfig,
+    storage::ConsensusStorage,
     types::CreateProposalRequest,
     utils::{build_vote, compute_vote_hash, validate_proposal},
 };
+
+async fn cast_remote_vote(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Vote,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
+    let vote = build_vote(&proposal, choice, signer).await?;
+    service.process_incoming_vote(scope, vote.clone()).await?;
+    Ok(vote)
+}
+
+async fn cast_remote_vote_and_get_proposal(
+    service: &DefaultConsensusService,
+    scope: &ScopeID,
+    proposal_id: u32,
+    choice: bool,
+    signer: &EthereumConsensusSigner,
+) -> Result<
+    hashgraph_like_consensus::protos::consensus::v1::Proposal,
+    hashgraph_like_consensus::error::ConsensusError,
+> {
+    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
+    service.storage().get_proposal(scope, proposal_id).await
+}
+
+fn make_service() -> DefaultConsensusService {
+    DefaultConsensusService::new(EthereumConsensusSigner::new(PrivateKeySigner::random()))
+}
 
 fn wrap(signer: PrivateKeySigner) -> EthereumConsensusSigner {
     EthereumConsensusSigner::new(signer)
@@ -49,7 +84,7 @@ async fn resign_vote(
 
 #[tokio::test]
 async fn test_vote_created_with_helper_is_valid() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -70,13 +105,18 @@ async fn test_vote_created_with_helper_is_valid() {
         .await
         .expect("proposal");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("proposal_owner vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let vote = build_vote(&proposal, VOTE_YES, wrap(voter))
+    let vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
         .await
         .expect("vote should be created");
 
@@ -88,7 +128,7 @@ async fn test_vote_created_with_helper_is_valid() {
 
 #[tokio::test]
 async fn test_invalid_signature_is_rejected() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -109,13 +149,18 @@ async fn test_invalid_signature_is_rejected() {
         .await
         .expect("proposal");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("proposal_owner vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(voter))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
         .await
         .expect("vote");
 
@@ -140,7 +185,7 @@ async fn test_invalid_signature_is_rejected() {
 
 #[tokio::test]
 async fn test_vote_chain_validation_rejects_bad_received_hash() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -161,18 +206,23 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
         .await
         .expect("proposal");
 
-    let proposal = service
-        .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES, wrap(proposal_owner))
-        .await
-        .expect("proposal_owner vote");
+    let proposal = cast_remote_vote_and_get_proposal(
+        &service,
+        &scope,
+        proposal.proposal_id,
+        VOTE_YES,
+        &wrap(proposal_owner),
+    )
+    .await
+    .expect("proposal_owner vote");
 
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, wrap(voter_one))
+    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one))
         .await
         .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, wrap(voter_two.clone()))
+    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone()))
         .await
         .expect("vote two");
 
@@ -201,7 +251,7 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
 
 #[tokio::test]
 async fn test_validate_proposal_rejects_empty_vote_owner() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -222,7 +272,7 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
         .await
         .expect("vote");
     vote.vote_owner.clear();
@@ -237,7 +287,7 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
 
 #[tokio::test]
 async fn test_validate_proposal_rejects_empty_vote_hash() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -258,7 +308,7 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
         .await
         .expect("vote");
     vote.vote_hash.clear();
@@ -273,7 +323,7 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
 
 #[tokio::test]
 async fn test_validate_proposal_rejects_empty_signature() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -294,7 +344,7 @@ async fn test_validate_proposal_rejects_empty_signature() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
         .await
         .expect("vote");
     vote.signature.clear();
@@ -309,7 +359,7 @@ async fn test_validate_proposal_rejects_empty_signature() {
 
 #[tokio::test]
 async fn test_validate_proposal_rejects_mismatched_signature_length() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -330,7 +380,7 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
         .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, wrap(proposal_owner))
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
         .await
         .expect("vote");
     vote.signature = vec![7; 64];
@@ -347,7 +397,7 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
 
 #[tokio::test]
 async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
-    let service = DefaultConsensusService::default();
+    let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -371,10 +421,10 @@ async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, wrap(voter_one))
+    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one))
         .await
         .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, wrap(voter_two.clone()))
+    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone()))
         .await
         .expect("vote two");
 


### PR DESCRIPTION
## Summary

Follow-up to PR #16. Each `ConsensusService` now holds its peer signer as a field, alongside its storage handle and event bus. `cast_vote` and `cast_vote_and_get_proposal` drop the per-call signer parameter and use the held signer instead.

The asymmetry pre-this PR (storage and event-bus held, signer passed per call) forced downstream consumers to thread the signer through their code (visible in the de-mls integration). With this change a `ConsensusService` represents one peer's view: storage, bus, and signer are all peer-scoped state held by the service.

### Changes

- `ConsensusSignatureScheme: Clone + Send + Sync + 'static`, matching `ConsensusStorage` and `ConsensusEventBus`.
- `ConsensusService<Scope, Storage, Event, Signer>` stores a `Signer` instance (was `PhantomData`).
- `cast_vote(&scope, id, choice)` and `cast_vote_and_get_proposal(&scope, id, choice)` drop the signer arg.
- Constructors take the signer:
  - `ConsensusService::new_with_components(storage, event_bus, signer, max_sessions)`
  - `DefaultConsensusService::new(signer)` / `new_with_max_sessions(signer, max)`
- `Default::default` for `DefaultConsensusService` is removed — no sensible identity to fabricate.
- New `ConsensusService::signer(&self) -> &Signer` accessor.
- `utils::build_vote` takes `signer: &Signer` (was by value).
- Bump to `0.4.0`; CHANGELOG, README, and lib doctest updated.

### Migration

```rust
// before
let service = DefaultConsensusService::default();
service.cast_vote(&scope, id, true, signer).await?;

// after
let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
let service = DefaultConsensusService::new(signer);
service.cast_vote(&scope, id, true).await?;
```

For multi-peer setups (one process simulating many identities), construct one `ConsensusService` per peer with shared storage and (optionally) a shared event bus — see the README "Service shape" section.

### Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features --tests -- -D warnings`
- [x] `cargo test --all-features --tests` (all 91 tests pass)
- [x] `cargo test --doc`
- [ ] CI green
