### PR TITLE
feat!: make the library fully synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.5.0
+
+**Breaking** — the library is now fully synchronous. Every method drops `async`
+and returns its value directly; remove `.await` from all call sites. `tokio` is
+no longer a dependency.
+
+### Changed
+
+- All `ConsensusService`, `ConsensusStorage`, and `ConsensusEventBus` methods,
+  plus `ConsensusSignatureScheme::sign` and `utils::build_vote`, are now sync:
+  ```rust
+  // before
+  let vote = service.cast_vote(&scope, id, choice).await?;
+  // after
+  let vote = service.cast_vote(&scope, id, choice)?;
+  ```
+- `ConsensusStorage::stream_scope_sessions` returns `impl Iterator<Item = ...>`
+  instead of a `futures::Stream`.
+- `BroadcastEventBus` now fans out over `std::sync::mpsc`. `subscribe()` returns
+  a `std::sync::mpsc::Receiver`; consume it with `recv()` / `try_recv()` /
+  `recv_timeout()` (was `recv().await`). Slow subscribers miss events rather than
+  blocking the publisher.
+- `InMemoryConsensusStorage` uses `parking_lot::RwLock` internally.
+- The default `EthereumConsensusSigner` signs via alloy's `SignerSync`.
+
+### Added
+
+- Optional `ethereum` feature (enabled by default) gating the alloy-backed
+  `EthereumConsensusSigner` and the `DefaultConsensusService` alias. Build with
+  `default-features = false` to drop the alloy dependency and supply your own
+  `ConsensusSignatureScheme`.
+
+### Migration
+
+Remove `.await` from every consensus call, drop `#[tokio::main]`/`#[tokio::test]`
+(no async runtime needed), and switch event subscribers from `recv().await` to a
+blocking `recv()` / `recv_timeout()`.
+
 ## 0.4.0
 
 **Breaking** — `ConsensusService` now holds its peer's signer instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.6",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-primitives",
 ]
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -230,7 +230,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
  "k256",
@@ -241,6 +241,7 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
 ]
@@ -355,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -369,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -387,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -403,19 +404,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -662,28 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -746,15 +725,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -762,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bitvec"
@@ -785,6 +764,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -834,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -876,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -910,12 +898,12 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -972,6 +960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1009,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1118,10 +1124,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1165,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1315,69 +1331,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1391,13 +1348,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1489,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
  "serde",
@@ -1499,25 +1451,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
 name = "hashgraph-like-consensus"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "alloy-signer",
- "async-stream",
- "futures",
  "parking_lot",
  "prost",
  "prost-build",
  "sha2",
  "thiserror",
- "tokio",
  "tracing",
  "uuid",
 ]
@@ -1560,12 +1503,21 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1682,9 +1634,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1708,11 +1660,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1775,15 +1728,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1792,20 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "multimap"
@@ -1825,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2457,8 +2399,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -2466,6 +2419,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -2526,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2586,17 +2548,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
  "keccak",
 ]
 
@@ -2612,19 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -2649,16 +2601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -2713,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -2818,34 +2760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,14 +2770,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -2872,7 +2786,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -2908,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2944,9 +2858,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -2956,9 +2870,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3012,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3025,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3035,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3048,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3159,18 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3280,18 +3185,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashgraph-like-consensus"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "A lightweight Rust library for making binary decisions in networks using hashgraph-style consensus"
 license = "MIT"
@@ -8,19 +8,24 @@ repository = "https://github.com/vacp2p/hashgraph-like-consensus"
 keywords = ["consensus", "hashgraph", "voting", "p2p", "gossipsub"]
 readme = "README.md"
 
+[features]
+default = ["ethereum"]
+ethereum = ["dep:alloy", "dep:alloy-signer"]
+
 [dependencies]
 prost = "0.13.5"
 tracing = "0.1.41"
 uuid = { version = "1.18.1", features = ["v4"] }
 
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "full"] }
 thiserror = "2.0.17"
 sha2 = "0.10.9"
-alloy-signer = "1.1.2"
-alloy = { version = "1.1.2", default-features = false, features = ["k256", "signer-local"] }
-futures = "0.3"
 parking_lot = "0.12.5"
-async-stream = "0.3.6"
+
+alloy-signer = { version = "1.1.2", optional = true }
+alloy = { version = "1.1.2", default-features = false, features = [
+    "k256",
+    "signer-local",
+], optional = true }
 
 [build-dependencies]
 prost-build = "0.13.5"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Add to your `Cargo.toml`:
 hashgraph-like-consensus = { git = "https://github.com/vacp2p/hashgraph-like-consensus" }
 ```
 
+The default `ethereum` feature bundles the alloy-backed `EthereumConsensusSigner`
+and `DefaultConsensusService`. If you supply your own `ConsensusSignatureScheme`,
+disable it to drop the alloy dependency:
+
+```toml
+[dependencies]
+hashgraph-like-consensus = { git = "...", default-features = false }
+```
+
 ## Quick Start
 
 ```rust
@@ -40,29 +49,26 @@ use hashgraph_like_consensus::{
 };
 use alloy::signers::local::PrivateKeySigner;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
     let service = DefaultConsensusService::new(signer.clone());
     let scope = ScopeID::from("example-scope");
 
     // Create a proposal
-    let proposal = service
-        .create_proposal(
-            &scope,
-            CreateProposalRequest::new(
-                "Upgrade contract".into(),   // name
-                b"Switch to v2".to_vec(),     // payload (bytes)
-                signer.identity().to_vec(),  // owner
-                3,                           // expected voters
-                60,                          // expiration (seconds from now)
-                true,                        // liveness: silent peers count as YES at timeout
-            )?,
-        )
-        .await?;
+    let proposal = service.create_proposal(
+        &scope,
+        CreateProposalRequest::new(
+            "Upgrade contract".into(),   // name
+            b"Switch to v2".to_vec(),     // payload (bytes)
+            signer.identity().to_vec(),  // owner
+            3,                           // expected voters
+            60,                          // expiration (seconds from now)
+            true,                        // liveness: silent peers count as YES at timeout
+        )?,
+    )?;
 
     // Cast a vote — the service uses its held signer.
-    let vote = service.cast_vote(&scope, proposal.proposal_id, true).await?;
+    let vote = service.cast_vote(&scope, proposal.proposal_id, true)?;
     println!("Recorded vote {}", vote.vote_id);
 
     Ok(())
@@ -151,8 +157,8 @@ let conv_b: ConsensusService<_, _, _, EthereumConsensusSigner> =
     );
 
 // Each conversation's subscribers only see its own events — no filtering needed.
-let mut events_a = conv_a.event_bus().subscribe();
-let mut events_b = conv_b.event_bus().subscribe();
+let events_a = conv_a.event_bus().subscribe();
+let events_b = conv_b.event_bus().subscribe();
 ```
 
 The same shape works for DB-backed storage: build one `Pool`/connection-bearing
@@ -227,66 +233,58 @@ let scope = ScopeID::from("team_votes");
 
 // Initialize with the builder
 service
-    .scope(&scope)
-    .await?
+    .scope(&scope)?
     .with_network_type(NetworkType::P2P)
     .with_threshold(0.75)
     .with_timeout(Duration::from_secs(120))
     .with_liveness_criteria(false)
-    .initialize()
-    .await?;
+    .initialize()?;
 
 // Update later (single field)
 service
-    .scope(&scope)
-    .await?
+    .scope(&scope)?
     .with_threshold(0.8)
-    .update()
-    .await?;
+    .update()?;
 ```
 
 Built-in presets are also available:
 
 ```rust
 // High confidence (threshold = 0.9)
-service.scope(&scope).await?.strict_consensus().initialize().await?;
+service.scope(&scope)?.strict_consensus().initialize()?;
 
 // Low latency (threshold = 0.6, timeout = 30 s)
-service.scope(&scope).await?.fast_consensus().initialize().await?;
+service.scope(&scope)?.fast_consensus().initialize()?;
 ```
 
 ### Working with Proposals
 
 ```rust
 // Create a proposal
-let proposal = service
-    .create_proposal(&scope, CreateProposalRequest::new(
-        "Upgrade contract".into(),
-        b"Switch to v2".to_vec(),
-        owner_address,
-        3,     // expected voters
-        60,    // expiration (seconds from now)
-        true,  // liveness: silent peers count as YES at timeout
-    )?)
-    .await?;
+let proposal = service.create_proposal(&scope, CreateProposalRequest::new(
+    "Upgrade contract".into(),
+    b"Switch to v2".to_vec(),
+    owner_address,
+    3,     // expected voters
+    60,    // expiration (seconds from now)
+    true,  // liveness: silent peers count as YES at timeout
+)?)?;
 
 // Process a proposal received from the network
-service.process_incoming_proposal(&scope, proposal).await?;
+service.process_incoming_proposal(&scope, proposal)?;
 ```
 
 ### Casting and Processing Votes
 
 ```rust
 // Cast your vote (yes = true, no = false) using the service's held signer.
-let vote = service.cast_vote(&scope, proposal_id, true).await?;
+let vote = service.cast_vote(&scope, proposal_id, true)?;
 
 // Cast a vote and get the updated proposal (useful for gossiping).
-let proposal = service
-    .cast_vote_and_get_proposal(&scope, proposal_id, true)
-    .await?;
+let proposal = service.cast_vote_and_get_proposal(&scope, proposal_id, true)?;
 
 // Process a vote received from the network (uses the service's scheme to verify).
-service.process_incoming_vote(&scope, vote).await?;
+service.process_incoming_vote(&scope, vote)?;
 ```
 
 ### Reading State (via Storage)
@@ -297,19 +295,19 @@ All reads go through `service.storage()`:
 use hashgraph_like_consensus::storage::ConsensusStorage;
 
 // Get the consensus result for a proposal (Ok(true) = YES, Ok(false) = NO)
-let result: bool = service.storage().get_consensus_result(&scope, proposal_id).await?;
+let result: bool = service.storage().get_consensus_result(&scope, proposal_id)?;
 
 // Get a proposal by ID
-let proposal = service.storage().get_proposal(&scope, proposal_id).await?;
+let proposal = service.storage().get_proposal(&scope, proposal_id)?;
 
 // List active proposals (empty Vec if none)
-let active: Vec<Proposal> = service.storage().get_active_proposals(&scope).await?;
+let active: Vec<Proposal> = service.storage().get_active_proposals(&scope)?;
 
 // List finalized proposals (proposal_id -> result)
-let reached: HashMap<u32, bool> = service.storage().get_reached_proposals(&scope).await?;
+let reached: HashMap<u32, bool> = service.storage().get_reached_proposals(&scope)?;
 
 // Delete all state for a scope (e.g. when a user leaves a group)
-service.storage().delete_scope(&scope).await?;
+service.storage().delete_scope(&scope)?;
 ```
 
 ### Handling Timeouts
@@ -331,10 +329,10 @@ The only case where timeout produces no result is a **tie** (equal YES and NO we
 after counting silent peers), which marks the session as failed.
 
 ```rust
-// Schedule a timeout (typically via tokio::time::sleep)
-tokio::time::sleep(config.consensus_timeout()).await;
+// Drive the timer however your app prefers, then call the handler when it fires.
+std::thread::sleep(config.consensus_timeout());
 
-match service.handle_consensus_timeout(&scope, proposal_id).await {
+match service.handle_consensus_timeout(&scope, proposal_id) {
     Ok(true)  => println!("Consensus: YES"),
     Ok(false) => println!("Consensus: NO"),
     Err(ConsensusError::InsufficientVotesAtTimeout) => {
@@ -353,10 +351,10 @@ actual votes — silent peers are not counted until timeout.
 use hashgraph_like_consensus::events::ConsensusEventBus;
 use hashgraph_like_consensus::types::ConsensusEvent;
 
-let mut rx = service.event_bus().subscribe();
+let rx = service.event_bus().subscribe();
 
-tokio::spawn(async move {
-    while let Ok((scope, event)) = rx.recv().await {
+std::thread::spawn(move || {
+    while let Ok((scope, event)) = rx.recv() {
         match event {
             ConsensusEvent::ConsensusReached { proposal_id, result, timestamp } => {
                 println!("Proposal {} -> {}", proposal_id, if result { "YES" } else { "NO" });
@@ -372,7 +370,7 @@ tokio::spawn(async move {
 ### Statistics
 
 ```rust
-let stats = service.get_scope_stats(&scope).await;
+let stats = service.get_scope_stats(&scope);
 println!(
     "Active: {}, Reached: {}, Failed: {}",
     stats.active_sessions, stats.consensus_reached, stats.failed_sessions
@@ -430,13 +428,12 @@ use hashgraph_like_consensus::signing::{
     ConsensusSchemeError, ConsensusSignatureScheme,
 };
 
-pub trait ConsensusSignatureScheme: Send + Sync {
+pub trait ConsensusSignatureScheme: Clone + Send + Sync + 'static {
     /// Identity bytes written into `Vote::vote_owner` (address, public key, etc.).
     fn identity(&self) -> &[u8];
 
     /// Sign a payload. Returns raw signature bytes (length scheme-specific).
-    fn sign(&self, payload: &[u8])
-        -> impl Future<Output = Result<Vec<u8>, ConsensusSchemeError>> + Send;
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError>;
 
     /// Static verification — no instance needed. The service calls this for
     /// every incoming vote.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,12 +1,17 @@
-use tokio::sync::broadcast;
+use std::sync::{
+    Arc,
+    mpsc::{self, Receiver, SyncSender, TrySendError},
+};
+
+use parking_lot::Mutex;
 
 use crate::{scope::ConsensusScope, types::ConsensusEvent};
 
 /// Trait for broadcasting consensus events to subscribers.
 ///
 /// Implement this to use your own event system (message queue, webhooks, etc.).
-/// The default `BroadcastEventBus` uses Tokio's broadcast channel, which works
-/// well for in-process event distribution.
+/// The default `BroadcastEventBus` fans out over standard-library channels, which
+/// works well for in-process event distribution.
 pub trait ConsensusEventBus<Scope>: Clone + Send + Sync + 'static
 where
     Scope: ConsensusScope,
@@ -20,17 +25,19 @@ where
     fn publish(&self, scope: Scope, event: ConsensusEvent);
 }
 
-/// Default event bus implementation using Tokio's broadcast channel.
+type Subscribers<Scope> = Arc<Mutex<Vec<SyncSender<(Scope, ConsensusEvent)>>>>;
+
+/// Sends every event to all current subscribers in-process.
 ///
-/// This broadcasts events to all subscribers within the same process. Events are sent
-/// to all active subscribers, and late subscribers miss events that occurred before
-/// they subscribed. Perfect for in-process event distribution.
+/// Each subscriber gets its own channel. If a subscriber joins late, it misses earlier events.
+/// If a subscriber's buffer is full, it simply misses new events without blocking.
 #[derive(Clone)]
 pub struct BroadcastEventBus<Scope>
 where
     Scope: ConsensusScope,
 {
-    sender: broadcast::Sender<(Scope, ConsensusEvent)>,
+    capacity: usize,
+    subscribers: Subscribers<Scope>,
 }
 
 impl<Scope> BroadcastEventBus<Scope>
@@ -39,11 +46,13 @@ where
 {
     /// Create a new broadcast event bus with a custom max_queued_events size.
     ///
-    /// The max_queued_events size determines how many events can be queued before subscribers
-    /// start missing events. Default is 1000.
+    /// The max_queued_events size determines how many events can be buffered per
+    /// subscriber before that subscriber starts missing events. Default is 1000.
     pub fn new(max_queued_events: usize) -> Self {
-        let (sender, _) = broadcast::channel(max_queued_events);
-        Self { sender }
+        Self {
+            capacity: max_queued_events,
+            subscribers: Arc::new(Mutex::new(Vec::new())),
+        }
     }
 }
 
@@ -60,13 +69,24 @@ impl<Scope> ConsensusEventBus<Scope> for BroadcastEventBus<Scope>
 where
     Scope: ConsensusScope,
 {
-    type Receiver = broadcast::Receiver<(Scope, ConsensusEvent)>;
+    type Receiver = Receiver<(Scope, ConsensusEvent)>;
 
     fn subscribe(&self) -> Self::Receiver {
-        self.sender.subscribe()
+        let (sender, receiver) = mpsc::sync_channel(self.capacity);
+        self.subscribers.lock().push(sender);
+        receiver
     }
 
     fn publish(&self, scope: Scope, event: ConsensusEvent) {
-        let _ = self.sender.send((scope, event));
+        let mut subscribers = self.subscribers.lock();
+        // Deliver to every live subscriber; drop senders whose receiver is gone,
+        // and skip (without blocking) any subscriber whose buffer is full.
+        subscribers.retain(
+            |sender| match sender.try_send((scope.clone(), event.clone())) {
+                Ok(()) => true,
+                Err(TrySendError::Full(_)) => true,
+                Err(TrySendError::Disconnected(_)) => false,
+            },
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! };
 //! use alloy::signers::local::PrivateKeySigner;
 //!
-//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
 //! let service = DefaultConsensusService::new(signer.clone());
 //! let scope = ScopeID::from("my-scope");
@@ -76,10 +76,9 @@
 //!             60,   // expiration (seconds from now)
 //!             true, // liveness: silent peers count as YES at timeout
 //!         )?,
-//!     )
-//!     .await?;
+//!     )?;
 //!
-//! let vote = service.cast_vote(&scope, proposal.proposal_id, true).await?;
+//! let vote = service.cast_vote(&scope, proposal.proposal_id, true)?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,21 +1,25 @@
 use std::marker::PhantomData;
-
-use tokio::time::Duration;
+use std::time::Duration;
 
 use crate::{
     error::ConsensusError,
-    events::{BroadcastEventBus, ConsensusEventBus},
+    events::ConsensusEventBus,
     protos::consensus::v1::{Proposal, Vote},
-    scope::{ConsensusScope, ScopeID},
+    scope::ConsensusScope,
     scope_config::{NetworkType, ScopeConfig, ScopeConfigBuilder},
     session::{ConsensusConfig, ConsensusSession, ConsensusState},
-    signing::{ConsensusSignatureScheme, EthereumConsensusSigner},
-    storage::{ConsensusStorage, InMemoryConsensusStorage},
+    signing::ConsensusSignatureScheme,
+    storage::ConsensusStorage,
     types::{ConsensusEvent, CreateProposalRequest, SessionTransition},
     utils::{
         build_vote, calculate_consensus_result, current_timestamp, validate_proposal_timestamp,
         validate_vote,
     },
+};
+#[cfg(feature = "ethereum")]
+use crate::{
+    events::BroadcastEventBus, scope::ScopeID, signing::EthereumConsensusSigner,
+    storage::InMemoryConsensusStorage,
 };
 /// The main service that handles proposals, votes, and consensus.
 ///
@@ -71,6 +75,9 @@ where
 /// [`EthereumConsensusSigner`] scheme. Intended for tests and single-node
 /// integrations. Production deployments typically construct
 /// [`ConsensusService`] directly with their own scheme.
+///
+/// Requires the default `ethereum` feature.
+#[cfg(feature = "ethereum")]
 pub type DefaultConsensusService = ConsensusService<
     ScopeID,
     InMemoryConsensusStorage<ScopeID>,
@@ -78,6 +85,7 @@ pub type DefaultConsensusService = ConsensusService<
     EthereumConsensusSigner,
 >;
 
+#[cfg(feature = "ethereum")]
 impl DefaultConsensusService {
     /// Create a service with in-memory storage, broadcast events, and the
     /// given signer. Defaults to 10 max sessions per scope.
@@ -167,36 +175,35 @@ where
     ///
     /// **Important:** The library does not schedule timeouts automatically.
     /// Your application MUST call [`handle_consensus_timeout`](Self::handle_consensus_timeout)
-    /// when the proposal's timeout elapses (e.g. via `tokio::time::sleep`).
-    /// Without this call, proposals with offline voters will remain stuck in the
-    /// `Active` state indefinitely, and the liveness criteria for silent peers
-    /// will never take effect.
+    /// when the proposal's timeout elapses. Without this call, proposals with
+    /// offline voters will remain stuck in the `Active` state indefinitely, and
+    /// the liveness criteria for silent peers will never take effect.
     ///
     /// Configuration is resolved from: proposal config > scope config > global default.
     /// If no config is provided, the scope's default configuration is used.
-    pub async fn create_proposal(
+    pub fn create_proposal(
         &self,
         scope: &Scope,
         request: CreateProposalRequest,
     ) -> Result<Proposal, ConsensusError> {
-        self.create_proposal_with_config(scope, request, None).await
+        self.create_proposal_with_config(scope, request, None)
     }
 
     /// Create a new proposal with an explicit [`ConsensusConfig`] override.
     ///
     /// Pass `None` to fall back to scope defaults (same as [`create_proposal`](Self::create_proposal)).
-    pub async fn create_proposal_with_config(
+    pub fn create_proposal_with_config(
         &self,
         scope: &Scope,
         request: CreateProposalRequest,
         config: Option<ConsensusConfig>,
     ) -> Result<Proposal, ConsensusError> {
         let proposal = request.into_proposal()?;
-        let config = self.resolve_config(scope, config, Some(&proposal)).await?;
+        let config = self.resolve_config(scope, config, Some(&proposal))?;
         let (session, _) =
             ConsensusSession::from_proposal::<Signer>(proposal.clone(), config.clone())?;
-        self.save_session(scope, session).await?;
-        self.trim_scope_sessions(scope).await?;
+        self.save_session(scope, session)?;
+        self.trim_scope_sessions(scope)?;
         Ok(proposal)
     }
 
@@ -205,26 +212,24 @@ where
     /// The vote is cryptographically signed and linked into the hashgraph
     /// chain. Returns the signed [`Vote`] for network propagation. Each peer
     /// (identity) can only vote once per proposal.
-    pub async fn cast_vote(
+    pub fn cast_vote(
         &self,
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
     ) -> Result<Vote, ConsensusError> {
-        let session = self.get_session(scope, proposal_id).await?;
+        let session = self.get_session(scope, proposal_id)?;
         validate_proposal_timestamp(session.proposal.expiration_timestamp)?;
 
         if session.votes.contains_key(self.signer.identity()) {
             return Err(ConsensusError::UserAlreadyVoted);
         }
 
-        let vote = build_vote(&session.proposal, choice, &self.signer).await?;
+        let vote = build_vote(&session.proposal, choice, &self.signer)?;
         let vote_clone = vote.clone();
-        let transition = self
-            .update_session(scope, proposal_id, move |session| {
-                session.add_vote(vote_clone)
-            })
-            .await?;
+        let transition = self.update_session(scope, proposal_id, move |session| {
+            session.add_vote(vote_clone)
+        })?;
         self.handle_transition(scope, proposal_id, transition);
         Ok(vote)
     }
@@ -233,14 +238,14 @@ where
     ///
     /// Convenience method useful for the proposal creator who wants to immediately
     /// gossip the updated proposal to peers.
-    pub async fn cast_vote_and_get_proposal(
+    pub fn cast_vote_and_get_proposal(
         &self,
         scope: &Scope,
         proposal_id: u32,
         choice: bool,
     ) -> Result<Proposal, ConsensusError> {
-        self.cast_vote(scope, proposal_id, choice).await?;
-        let session = self.get_session(scope, proposal_id).await?;
+        self.cast_vote(scope, proposal_id, choice)?;
+        let session = self.get_session(scope, proposal_id)?;
         Ok(session.proposal)
     }
 
@@ -252,19 +257,19 @@ where
     ///
     /// Validates the proposal and all embedded votes, then stores it locally.
     /// If enough votes are already present, consensus is reached immediately.
-    pub async fn process_incoming_proposal(
+    pub fn process_incoming_proposal(
         &self,
         scope: &Scope,
         proposal: Proposal,
     ) -> Result<(), ConsensusError> {
-        if self.get_session(scope, proposal.proposal_id).await.is_ok() {
+        if self.get_session(scope, proposal.proposal_id).is_ok() {
             return Err(ConsensusError::ProposalAlreadyExist);
         }
-        let config = self.resolve_config(scope, None, Some(&proposal)).await?;
+        let config = self.resolve_config(scope, None, Some(&proposal))?;
         let (session, transition) = ConsensusSession::from_proposal::<Signer>(proposal, config)?;
         self.handle_transition(scope, session.proposal.proposal_id, transition);
-        self.save_session(scope, session).await?;
-        self.trim_scope_sessions(scope).await?;
+        self.save_session(scope, session)?;
+        self.trim_scope_sessions(scope)?;
         Ok(())
     }
 
@@ -273,21 +278,16 @@ where
     /// Call this when your networking layer delivers a vote from another peer.
     /// Validates the vote (signature, timestamp, chain) and adds it to the
     /// corresponding proposal session. May trigger consensus.
-    pub async fn process_incoming_vote(
-        &self,
-        scope: &Scope,
-        vote: Vote,
-    ) -> Result<(), ConsensusError> {
-        let session = self.get_session(scope, vote.proposal_id).await?;
+    pub fn process_incoming_vote(&self, scope: &Scope, vote: Vote) -> Result<(), ConsensusError> {
+        let session = self.get_session(scope, vote.proposal_id)?;
         validate_vote::<Signer>(
             &vote,
             session.proposal.expiration_timestamp,
             session.proposal.timestamp,
         )?;
         let proposal_id = vote.proposal_id;
-        let transition = self
-            .update_session(scope, proposal_id, move |session| session.add_vote(vote))
-            .await?;
+        let transition =
+            self.update_session(scope, proposal_id, move |session| session.add_vote(vote))?;
         self.handle_transition(scope, proposal_id, transition);
         Ok(())
     }
@@ -295,10 +295,9 @@ where
     /// Handle the timeout for a proposal.
     ///
     /// **The library does not call this automatically.** Your application MUST
-    /// schedule a timer (e.g. `tokio::time::sleep(config.consensus_timeout())`)
-    /// and invoke this method when it fires. Without this call, proposals with
-    /// offline voters will stay in the `Active` state forever and silent-peer
-    /// liveness logic will never run.
+    /// schedule a timer for `config.consensus_timeout()` and invoke this method
+    /// when it fires. Without this call, proposals with offline voters will stay
+    /// in the `Active` state forever and silent-peer liveness logic will never run.
     ///
     /// At timeout, silent peers are counted toward quorum using the proposal's
     /// `liveness_criteria_yes` flag (RFC Section 4, Silent Node Management):
@@ -309,13 +308,13 @@ where
     /// Returns the consensus result if determinable, or
     /// [`InsufficientVotesAtTimeout`](ConsensusError::InsufficientVotesAtTimeout)
     /// if the result is a tie after counting silent peers.
-    pub async fn handle_consensus_timeout(
+    pub fn handle_consensus_timeout(
         &self,
         scope: &Scope,
         proposal_id: u32,
     ) -> Result<bool, ConsensusError> {
-        let timeout_result: Result<Option<bool>, ConsensusError> = self
-            .update_session(scope, proposal_id, |session| {
+        let timeout_result: Result<Option<bool>, ConsensusError> =
+            self.update_session(scope, proposal_id, |session| {
                 if let ConsensusState::ConsensusReached(result) = session.state {
                     return Ok(Some(result));
                 }
@@ -333,8 +332,7 @@ where
                     session.state = ConsensusState::Failed;
                     Ok(None)
                 }
-            })
-            .await;
+            });
 
         match timeout_result? {
             Some(consensus_result) => {
@@ -376,36 +374,32 @@ where
     /// use alloy::signers::local::PrivateKeySigner;
     /// use std::time::Duration;
     ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///   let signer = EthereumConsensusSigner::new(PrivateKeySigner::random());
     ///   let service = DefaultConsensusService::new(signer);
     ///   let scope = ScopeID::from("my_scope");
     ///
     ///   // Initialize new scope
     ///   service
-    ///     .scope(&scope)
-    ///     .await?
+    ///     .scope(&scope)?
     ///     .with_network_type(NetworkType::P2P)
     ///     .with_threshold(0.75)
     ///     .with_timeout(Duration::from_secs(120))
-    ///     .initialize()
-    ///     .await?;
+    ///     .initialize()?;
     ///
     ///   // Update existing scope (single field)
     ///   service
-    ///     .scope(&scope)
-    ///     .await?
+    ///     .scope(&scope)?
     ///     .with_threshold(0.8)
-    ///     .update()
-    ///     .await?;
+    ///     .update()?;
     ///   Ok(())
     /// }
     /// ```
-    pub async fn scope(
+    pub fn scope(
         &self,
         scope: &Scope,
     ) -> Result<ScopeConfigBuilderWrapper<Scope, Storage, Event, Signer>, ConsensusError> {
-        let existing_config = self.storage.get_scope_config(scope).await?;
+        let existing_config = self.storage.get_scope_config(scope)?;
         let builder = if let Some(config) = existing_config {
             ScopeConfigBuilder::from_existing(config)
         } else {
@@ -418,27 +412,23 @@ where
         ))
     }
 
-    async fn initialize_scope(
-        &self,
-        scope: &Scope,
-        config: ScopeConfig,
-    ) -> Result<(), ConsensusError> {
+    fn initialize_scope(&self, scope: &Scope, config: ScopeConfig) -> Result<(), ConsensusError> {
         config.validate()?;
-        self.storage.set_scope_config(scope, config).await
+        self.storage.set_scope_config(scope, config)
     }
 
-    async fn update_scope_config<F>(&self, scope: &Scope, updater: F) -> Result<(), ConsensusError>
+    fn update_scope_config<F>(&self, scope: &Scope, updater: F) -> Result<(), ConsensusError>
     where
-        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError> + Send,
+        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError>,
     {
-        self.storage.update_scope_config(scope, updater).await
+        self.storage.update_scope_config(scope, updater)
     }
 
     /// Resolve configuration for a proposal.
     ///
     /// Priority: proposal override > proposal fields (expiration_timestamp, liveness_criteria_yes)
     ///   > scope config > global default
-    async fn resolve_config(
+    fn resolve_config(
         &self,
         scope: &Scope,
         proposal_override: Option<ConsensusConfig>,
@@ -450,7 +440,7 @@ where
         let has_explicit_override = proposal_override.is_some();
         let base_config = if let Some(override_config) = proposal_override {
             override_config
-        } else if let Some(scope_config) = self.storage.get_scope_config(scope).await? {
+        } else if let Some(scope_config) = self.storage.get_scope_config(scope)? {
             ConsensusConfig::from(scope_config)
         } else {
             ConsensusConfig::gossipsub()
@@ -480,61 +470,50 @@ where
         }
     }
 
-    async fn get_session(
+    fn get_session(
         &self,
         scope: &Scope,
         proposal_id: u32,
     ) -> Result<ConsensusSession, ConsensusError> {
         self.storage
-            .get_session(scope, proposal_id)
-            .await?
+            .get_session(scope, proposal_id)?
             .ok_or(ConsensusError::SessionNotFound)
     }
 
-    async fn update_session<R, F>(
+    fn update_session<R, F>(
         &self,
         scope: &Scope,
         proposal_id: u32,
         mutator: F,
     ) -> Result<R, ConsensusError>
     where
-        R: Send,
-        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError> + Send,
+        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError>,
     {
-        self.storage
-            .update_session(scope, proposal_id, mutator)
-            .await
+        self.storage.update_session(scope, proposal_id, mutator)
     }
 
-    async fn save_session(
-        &self,
-        scope: &Scope,
-        session: ConsensusSession,
-    ) -> Result<(), ConsensusError> {
-        self.storage.save_session(scope, session).await
+    fn save_session(&self, scope: &Scope, session: ConsensusSession) -> Result<(), ConsensusError> {
+        self.storage.save_session(scope, session)
     }
 
-    async fn trim_scope_sessions(&self, scope: &Scope) -> Result<(), ConsensusError> {
-        self.storage
-            .update_scope_sessions(scope, |sessions| {
-                if sessions.len() <= self.max_sessions_per_scope {
-                    return Ok(());
-                }
+    fn trim_scope_sessions(&self, scope: &Scope) -> Result<(), ConsensusError> {
+        self.storage.update_scope_sessions(scope, |sessions| {
+            if sessions.len() <= self.max_sessions_per_scope {
+                return Ok(());
+            }
 
-                sessions.sort_by_key(|s| std::cmp::Reverse(s.created_at));
-                sessions.truncate(self.max_sessions_per_scope);
-                Ok(())
-            })
-            .await
+            sessions.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+            sessions.truncate(self.max_sessions_per_scope);
+            Ok(())
+        })
     }
 
-    pub(crate) async fn list_scope_sessions(
+    pub(crate) fn list_scope_sessions(
         &self,
         scope: &Scope,
     ) -> Result<Vec<ConsensusSession>, ConsensusError> {
         self.storage
-            .list_scope_sessions(scope)
-            .await?
+            .list_scope_sessions(scope)?
             .ok_or(ConsensusError::ScopeNotFound)
     }
 
@@ -649,20 +628,18 @@ where
     }
 
     /// Initialize scope with the built configuration
-    pub async fn initialize(self) -> Result<(), ConsensusError> {
+    pub fn initialize(self) -> Result<(), ConsensusError> {
         let config = self.builder.build()?;
-        self.service.initialize_scope(&self.scope, config).await
+        self.service.initialize_scope(&self.scope, config)
     }
 
     /// Update existing scope configuration with the built configuration
-    pub async fn update(self) -> Result<(), ConsensusError> {
+    pub fn update(self) -> Result<(), ConsensusError> {
         let config = self.builder.build()?;
-        self.service
-            .update_scope_config(&self.scope, |existing| {
-                *existing = config;
-                Ok(())
-            })
-            .await
+        self.service.update_scope_config(&self.scope, |existing| {
+            *existing = config;
+            Ok(())
+        })
     }
 
     /// Get the current configuration (useful for testing)

--- a/src/service_stats.rs
+++ b/src/service_stats.rs
@@ -29,9 +29,8 @@ where
     ///
     /// Returns counts of total, active, failed, and finalized proposals.
     /// Useful for monitoring and dashboards.
-    pub async fn get_scope_stats(&self, scope: &Scope) -> ConsensusStats {
+    pub fn get_scope_stats(&self, scope: &Scope) -> ConsensusStats {
         self.list_scope_sessions(scope)
-            .await
             .map(|scope_sessions| {
                 let total_sessions = scope_sessions.len();
                 let active_sessions = scope_sessions.iter().filter(|s| s.is_active()).count();

--- a/src/session.rs
+++ b/src/session.rs
@@ -413,8 +413,8 @@ mod tests {
         EthereumConsensusSigner::new(signer)
     }
 
-    #[tokio::test]
-    async fn enforce_max_rounds_gossipsub() {
+    #[test]
+    fn enforce_max_rounds_gossipsub() {
         // Gossipsub: max_rounds = 2 means round 1 (proposal) and round 2 (all votes)
         // Should allow multiple votes in round 2, but not exceed round 2
         let signer1 = PrivateKeySigner::random();
@@ -437,37 +437,29 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote)
-        let vote1 = build_vote(&session.proposal, true, &wrap(signer1))
-            .await
-            .unwrap();
+        let vote1 = build_vote(&session.proposal, true, &wrap(signer1)).unwrap();
         session.add_vote(vote1).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (second vote)
-        let vote2 = build_vote(&session.proposal, false, &wrap(signer2))
-            .await
-            .unwrap();
+        let vote2 = build_vote(&session.proposal, false, &wrap(signer2)).unwrap();
         session.add_vote(vote2).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (third vote)
-        let vote3 = build_vote(&session.proposal, true, &wrap(signer3))
-            .await
-            .unwrap();
+        let vote3 = build_vote(&session.proposal, true, &wrap(signer3)).unwrap();
         session.add_vote(vote3).unwrap();
         assert_eq!(session.proposal.round, 2);
 
         // Stay at round 2 (fourth vote) - should succeed
-        let vote4 = build_vote(&session.proposal, true, &wrap(signer4))
-            .await
-            .unwrap();
+        let vote4 = build_vote(&session.proposal, true, &wrap(signer4)).unwrap();
         session.add_vote(vote4).unwrap();
         assert_eq!(session.proposal.round, 2);
         assert_eq!(session.votes.len(), 4);
     }
 
-    #[tokio::test]
-    async fn enforce_max_rounds_p2p() {
+    #[test]
+    fn enforce_max_rounds_p2p() {
         // P2P defaults: max_rounds = 0 triggers dynamic calculation based on expected voters.
         // For threshold=2/3 and expected_voters=5, max_round_limit = ceil(2n/3) = 4 votes.
         // Round 1 = 0 votes, Round 2 = 1 vote, ... Round 5 = 4 votes.
@@ -492,41 +484,31 @@ mod tests {
         let mut session = ConsensusSession::new(proposal, config);
 
         // Round 1 -> Round 2 (first vote, 1 vote total)
-        let vote1 = build_vote(&session.proposal, true, &wrap(signer1))
-            .await
-            .unwrap();
+        let vote1 = build_vote(&session.proposal, true, &wrap(signer1)).unwrap();
         session.add_vote(vote1).unwrap();
         assert_eq!(session.proposal.round, 2);
         assert_eq!(session.votes.len(), 1);
 
         // Round 2 -> Round 3 (second vote, 2 votes total) - should succeed
-        let vote2 = build_vote(&session.proposal, false, &wrap(signer2))
-            .await
-            .unwrap();
+        let vote2 = build_vote(&session.proposal, false, &wrap(signer2)).unwrap();
         session.add_vote(vote2).unwrap();
         assert_eq!(session.proposal.round, 3);
         assert_eq!(session.votes.len(), 2);
 
         // Round 3 -> Round 4 (third vote, 3 votes total) - should succeed
-        let vote3 = build_vote(&session.proposal, true, &wrap(signer3))
-            .await
-            .unwrap();
+        let vote3 = build_vote(&session.proposal, true, &wrap(signer3)).unwrap();
         session.add_vote(vote3).unwrap();
         assert_eq!(session.proposal.round, 4);
         assert_eq!(session.votes.len(), 3);
 
         // Round 4 -> Round 5 (fourth vote, 4 votes total) - should succeed (dynamic limit = 4)
-        let vote4 = build_vote(&session.proposal, true, &wrap(signer4))
-            .await
-            .unwrap();
+        let vote4 = build_vote(&session.proposal, true, &wrap(signer4)).unwrap();
         session.add_vote(vote4).unwrap();
         assert_eq!(session.proposal.round, 5);
         assert_eq!(session.votes.len(), 4);
 
         // Fifth vote would exceed dynamic max_round_limit (=4 votes)
-        let vote5 = build_vote(&session.proposal, true, &wrap(signer5))
-            .await
-            .unwrap();
+        let vote5 = build_vote(&session.proposal, true, &wrap(signer5)).unwrap();
         let err = session.add_vote(vote5).unwrap_err();
         assert!(matches!(err, ConsensusError::MaxRoundsExceeded));
     }
@@ -559,8 +541,8 @@ mod tests {
         assert_eq!(explicit.max_round_limit(100), 7);
     }
 
-    #[tokio::test]
-    async fn add_vote_rejects_non_active_and_reports_reached_when_finalized() {
+    #[test]
+    fn add_vote_rejects_non_active_and_reports_reached_when_finalized() {
         let signer = PrivateKeySigner::random();
         let request = CreateProposalRequest::new(
             "Test".into(),
@@ -577,18 +559,14 @@ mod tests {
         let mut failed_session =
             ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
         failed_session.state = ConsensusState::Failed;
-        let vote = build_vote(&failed_session.proposal, true, &wrap(signer.clone()))
-            .await
-            .unwrap();
+        let vote = build_vote(&failed_session.proposal, true, &wrap(signer.clone())).unwrap();
         let err = failed_session.add_vote(vote).unwrap_err();
         assert!(matches!(err, ConsensusError::SessionNotActive));
 
         // Finalized sessions return existing transition/result.
         let mut finalized_session = ConsensusSession::new(proposal, ConsensusConfig::gossipsub());
         finalized_session.state = ConsensusState::ConsensusReached(true);
-        let vote = build_vote(&finalized_session.proposal, true, &wrap(signer))
-            .await
-            .unwrap();
+        let vote = build_vote(&finalized_session.proposal, true, &wrap(signer)).unwrap();
         let transition = finalized_session.add_vote(vote).unwrap();
         assert!(matches!(
             transition,
@@ -596,8 +574,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn initialize_with_votes_non_active_duplicate_and_zero_votes_paths() {
+    #[test]
+    fn initialize_with_votes_non_active_duplicate_and_zero_votes_paths() {
         let signer = PrivateKeySigner::random();
         let request = CreateProposalRequest::new(
             "Test".into(),
@@ -624,12 +602,8 @@ mod tests {
 
         // Duplicate owners are rejected before chain/signature checks.
         let mut dup_session = ConsensusSession::new(proposal.clone(), ConsensusConfig::gossipsub());
-        let vote1 = build_vote(&dup_session.proposal, true, &wrap(signer.clone()))
-            .await
-            .unwrap();
-        let vote2 = build_vote(&dup_session.proposal, false, &wrap(signer))
-            .await
-            .unwrap();
+        let vote1 = build_vote(&dup_session.proposal, true, &wrap(signer.clone())).unwrap();
+        let vote2 = build_vote(&dup_session.proposal, false, &wrap(signer)).unwrap();
         let err = dup_session
             .initialize_with_votes::<EthereumConsensusSigner>(
                 vec![vote1, vote2],

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -18,9 +18,9 @@
 //! [`Vote::signature`]: crate::protos::consensus::v1::Vote::signature
 //! [`DefaultConsensusService`]: crate::service::DefaultConsensusService
 
-use std::future::Future;
-
+#[cfg(feature = "ethereum")]
 mod ethereum;
+#[cfg(feature = "ethereum")]
 pub use ethereum::EthereumConsensusSigner;
 
 /// A signature scheme that the consensus service uses to sign and verify votes.
@@ -55,10 +55,7 @@ pub trait ConsensusSignatureScheme: Clone + Send + Sync + 'static {
     /// Sign `payload` and return the raw signature bytes.
     ///
     /// Length and encoding are scheme-specific.
-    fn sign(
-        &self,
-        payload: &[u8],
-    ) -> impl Future<Output = Result<Vec<u8>, ConsensusSchemeError>> + Send;
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError>;
 
     /// Verify that `signature` over `payload` was produced by the holder of
     /// `identity`.

--- a/src/signing/ethereum.rs
+++ b/src/signing/ethereum.rs
@@ -2,7 +2,7 @@
 //!
 use alloy::primitives::Address;
 use alloy::signers::local::PrivateKeySigner;
-use alloy_signer::{Signature, Signer};
+use alloy_signer::{Signature, SignerSync};
 
 use super::{ConsensusSchemeError, ConsensusSignatureScheme};
 
@@ -55,11 +55,10 @@ impl ConsensusSignatureScheme for EthereumConsensusSigner {
         &self.address_bytes
     }
 
-    async fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
         let signature = self
             .inner
-            .sign_message(payload)
-            .await
+            .sign_message_sync(payload)
             .map_err(|e| ConsensusSchemeError::Sign(e.to_string()))?;
         Ok(signature.as_bytes().to_vec())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,10 +4,8 @@
 //! other durable backend. The provided [`InMemoryConsensusStorage`] keeps everything
 //! in RAM and is suitable for testing or single-node deployments.
 
-use async_stream::try_stream;
-use futures::Stream;
+use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
 
 use crate::{
     error::ConsensusError,
@@ -27,49 +25,43 @@ where
     Scope: ConsensusScope,
 {
     /// Persist a session (insert or overwrite by `proposal_id`).
-    fn save_session(
-        &self,
-        scope: &Scope,
-        session: ConsensusSession,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+    fn save_session(&self, scope: &Scope, session: ConsensusSession) -> Result<(), ConsensusError>;
 
     /// Retrieve a session by proposal ID, or `None` if it doesn't exist.
     fn get_session(
         &self,
         scope: &Scope,
         proposal_id: u32,
-    ) -> impl Future<Output = Result<Option<ConsensusSession>, ConsensusError>> + Send;
+    ) -> Result<Option<ConsensusSession>, ConsensusError>;
 
     /// Remove and return a session, or `None` if not found.
     fn remove_session(
         &self,
         scope: &Scope,
         proposal_id: u32,
-    ) -> impl Future<Output = Result<Option<ConsensusSession>, ConsensusError>> + Send;
+    ) -> Result<Option<ConsensusSession>, ConsensusError>;
 
     /// List all sessions in a scope, or `None` if the scope doesn't exist.
     fn list_scope_sessions(
         &self,
         scope: &Scope,
-    ) -> impl Future<Output = Result<Option<Vec<ConsensusSession>>, ConsensusError>> + Send;
+    ) -> Result<Option<Vec<ConsensusSession>>, ConsensusError>;
 
-    /// Stream sessions in a scope one at a time (useful for large scopes).
-    fn stream_scope_sessions<'a>(
-        &'a self,
-        scope: &'a Scope,
-    ) -> impl Stream<Item = Result<ConsensusSession, ConsensusError>> + Send + 'a;
+    /// Iterate sessions in a scope one at a time (useful for large scopes).
+    fn stream_scope_sessions(
+        &self,
+        scope: &Scope,
+    ) -> impl Iterator<Item = Result<ConsensusSession, ConsensusError>>;
 
     /// Replace all sessions in a scope atomically.
     fn replace_scope_sessions(
         &self,
         scope: &Scope,
         sessions: Vec<ConsensusSession>,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+    ) -> Result<(), ConsensusError>;
 
     /// List all known scopes, or `None` if no scopes exist.
-    fn list_scopes(
-        &self,
-    ) -> impl Future<Output = Result<Option<Vec<Scope>>, ConsensusError>> + Send;
+    fn list_scopes(&self) -> Result<Option<Vec<Scope>>, ConsensusError>;
 
     /// Apply a mutation to a single session in place.
     fn update_session<R, F>(
@@ -77,51 +69,32 @@ where
         scope: &Scope,
         proposal_id: u32,
         mutator: F,
-    ) -> impl Future<Output = Result<R, ConsensusError>> + Send
+    ) -> Result<R, ConsensusError>
     where
-        R: Send,
-        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError> + Send;
+        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError>;
 
     /// Apply a mutation to all sessions in a scope (e.g. trimming old entries).
-    fn update_scope_sessions<F>(
-        &self,
-        scope: &Scope,
-        mutator: F,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send
+    fn update_scope_sessions<F>(&self, scope: &Scope, mutator: F) -> Result<(), ConsensusError>
     where
-        F: FnOnce(&mut Vec<ConsensusSession>) -> Result<(), ConsensusError> + Send;
+        F: FnOnce(&mut Vec<ConsensusSession>) -> Result<(), ConsensusError>;
 
     /// Get the scope-level configuration, or `None` if not yet initialized.
-    fn get_scope_config(
-        &self,
-        scope: &Scope,
-    ) -> impl Future<Output = Result<Option<ScopeConfig>, ConsensusError>> + Send;
+    fn get_scope_config(&self, scope: &Scope) -> Result<Option<ScopeConfig>, ConsensusError>;
 
     /// Set (insert or overwrite) the scope-level configuration.
-    fn set_scope_config(
-        &self,
-        scope: &Scope,
-        config: ScopeConfig,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+    fn set_scope_config(&self, scope: &Scope, config: ScopeConfig) -> Result<(), ConsensusError>;
 
     /// Remove all data for a scope (sessions, config, everything).
     ///
     /// Called when a group is left or deleted. After this call, the scope
     /// behaves as if it was never initialized — creating new proposals on it
     /// starts fresh.
-    fn delete_scope(
-        &self,
-        scope: &Scope,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send;
+    fn delete_scope(&self, scope: &Scope) -> Result<(), ConsensusError>;
 
     /// Apply a mutation to an existing scope configuration.
-    fn update_scope_config<F>(
-        &self,
-        scope: &Scope,
-        updater: F,
-    ) -> impl Future<Output = Result<(), ConsensusError>> + Send
+    fn update_scope_config<F>(&self, scope: &Scope, updater: F) -> Result<(), ConsensusError>
     where
-        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError> + Send;
+        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError>;
 
     // ── Query helpers (default implementations) ────────────────────────
     //
@@ -140,18 +113,15 @@ where
         &self,
         scope: &Scope,
         proposal_id: u32,
-    ) -> impl Future<Output = Result<bool, ConsensusError>> + Send {
-        async move {
-            use crate::session::ConsensusState;
-            let session = self
-                .get_session(scope, proposal_id)
-                .await?
-                .ok_or(ConsensusError::SessionNotFound)?;
-            match session.state {
-                ConsensusState::ConsensusReached(result) => Ok(result),
-                ConsensusState::Failed => Err(ConsensusError::ConsensusFailed),
-                ConsensusState::Active => Err(ConsensusError::ConsensusNotReached),
-            }
+    ) -> Result<bool, ConsensusError> {
+        use crate::session::ConsensusState;
+        let session = self
+            .get_session(scope, proposal_id)?
+            .ok_or(ConsensusError::SessionNotFound)?;
+        match session.state {
+            ConsensusState::ConsensusReached(result) => Ok(result),
+            ConsensusState::Failed => Err(ConsensusError::ConsensusFailed),
+            ConsensusState::Active => Err(ConsensusError::ConsensusNotReached),
         }
     }
 
@@ -159,18 +129,11 @@ where
     ///
     /// Returns [`SessionNotFound`](ConsensusError::SessionNotFound) if the
     /// proposal doesn't exist.
-    fn get_proposal(
-        &self,
-        scope: &Scope,
-        proposal_id: u32,
-    ) -> impl Future<Output = Result<Proposal, ConsensusError>> + Send {
-        async move {
-            let session = self
-                .get_session(scope, proposal_id)
-                .await?
-                .ok_or(ConsensusError::SessionNotFound)?;
-            Ok(session.proposal)
-        }
+    fn get_proposal(&self, scope: &Scope, proposal_id: u32) -> Result<Proposal, ConsensusError> {
+        let session = self
+            .get_session(scope, proposal_id)?
+            .ok_or(ConsensusError::SessionNotFound)?;
+        Ok(session.proposal)
     }
 
     /// Get the resolved configuration for a proposal.
@@ -181,52 +144,39 @@ where
         &self,
         scope: &Scope,
         proposal_id: u32,
-    ) -> impl Future<Output = Result<ConsensusConfig, ConsensusError>> + Send {
-        async move {
-            let session = self
-                .get_session(scope, proposal_id)
-                .await?
-                .ok_or(ConsensusError::SessionNotFound)?;
-            Ok(session.config)
-        }
+    ) -> Result<ConsensusConfig, ConsensusError> {
+        let session = self
+            .get_session(scope, proposal_id)?
+            .ok_or(ConsensusError::SessionNotFound)?;
+        Ok(session.config)
     }
 
     /// Get all proposals that are still accepting votes.
     ///
     /// Returns an empty `Vec` if no active proposals exist or the scope is unknown.
-    fn get_active_proposals(
-        &self,
-        scope: &Scope,
-    ) -> impl Future<Output = Result<Vec<Proposal>, ConsensusError>> + Send {
-        async move {
-            let sessions = self.list_scope_sessions(scope).await?.unwrap_or_default();
-            Ok(sessions
-                .into_iter()
-                .filter(|s| s.is_active())
-                .map(|s| s.proposal)
-                .collect())
-        }
+    fn get_active_proposals(&self, scope: &Scope) -> Result<Vec<Proposal>, ConsensusError> {
+        let sessions = self.list_scope_sessions(scope)?.unwrap_or_default();
+        Ok(sessions
+            .into_iter()
+            .filter(|s| s.is_active())
+            .map(|s| s.proposal)
+            .collect())
     }
 
     /// Get all proposals that reached consensus, with their results.
     ///
     /// Returns a map from `proposal_id` to result (`true` = YES, `false` = NO).
     /// Returns an empty map if no proposals reached consensus or the scope is unknown.
-    fn get_reached_proposals(
-        &self,
-        scope: &Scope,
-    ) -> impl Future<Output = Result<HashMap<u32, bool>, ConsensusError>> + Send {
-        async move {
-            let sessions = self.list_scope_sessions(scope).await?.unwrap_or_default();
-            Ok(sessions
-                .into_iter()
-                .filter_map(|s| {
-                    s.get_consensus_result()
-                        .ok()
-                        .map(|result| (s.proposal.proposal_id, result))
-                })
-                .collect())
-        }
+    fn get_reached_proposals(&self, scope: &Scope) -> Result<HashMap<u32, bool>, ConsensusError> {
+        let sessions = self.list_scope_sessions(scope)?.unwrap_or_default();
+        Ok(sessions
+            .into_iter()
+            .filter_map(|s| {
+                s.get_consensus_result()
+                    .ok()
+                    .map(|result| (s.proposal.proposal_id, result))
+            })
+            .collect())
     }
 }
 
@@ -272,72 +222,65 @@ impl<Scope> ConsensusStorage<Scope> for InMemoryConsensusStorage<Scope>
 where
     Scope: ConsensusScope + Clone,
 {
-    async fn save_session(
-        &self,
-        scope: &Scope,
-        session: ConsensusSession,
-    ) -> Result<(), ConsensusError> {
-        let mut sessions = self.sessions.write().await;
+    fn save_session(&self, scope: &Scope, session: ConsensusSession) -> Result<(), ConsensusError> {
+        let mut sessions = self.sessions.write();
         let entry = sessions.entry(scope.clone()).or_default();
         entry.insert(session.proposal.proposal_id, session);
         Ok(())
     }
 
-    async fn get_session(
+    fn get_session(
         &self,
         scope: &Scope,
         proposal_id: u32,
     ) -> Result<Option<ConsensusSession>, ConsensusError> {
-        let sessions = self.sessions.read().await;
+        let sessions = self.sessions.read();
         Ok(sessions
             .get(scope)
             .and_then(|scope| scope.get(&proposal_id))
             .cloned())
     }
 
-    async fn remove_session(
+    fn remove_session(
         &self,
         scope: &Scope,
         proposal_id: u32,
     ) -> Result<Option<ConsensusSession>, ConsensusError> {
-        let mut sessions = self.sessions.write().await;
+        let mut sessions = self.sessions.write();
         Ok(sessions
             .get_mut(scope)
             .and_then(|scope| scope.remove(&proposal_id)))
     }
 
-    async fn list_scope_sessions(
+    fn list_scope_sessions(
         &self,
         scope: &Scope,
     ) -> Result<Option<Vec<ConsensusSession>>, ConsensusError> {
-        let sessions = self.sessions.read().await;
+        let sessions = self.sessions.read();
         let result = sessions
             .get(scope)
             .map(|scope| scope.values().cloned().collect::<Vec<ConsensusSession>>());
         Ok(result)
     }
 
-    fn stream_scope_sessions<'a>(
-        &'a self,
-        scope: &'a Scope,
-    ) -> impl Stream<Item = Result<ConsensusSession, ConsensusError>> + Send + 'a {
-        try_stream! {
-            let guard = self.sessions.read().await;
-
-            if let Some(inner_map) = guard.get(scope) {
-                for session in inner_map.values() {
-                    yield session.clone();
-                }
-            }
-        }
+    fn stream_scope_sessions(
+        &self,
+        scope: &Scope,
+    ) -> impl Iterator<Item = Result<ConsensusSession, ConsensusError>> {
+        let guard = self.sessions.read();
+        let sessions = guard
+            .get(scope)
+            .map(|inner_map| inner_map.values().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+        sessions.into_iter().map(Ok)
     }
 
-    async fn replace_scope_sessions(
+    fn replace_scope_sessions(
         &self,
         scope: &Scope,
         sessions_list: Vec<ConsensusSession>,
     ) -> Result<(), ConsensusError> {
-        let mut sessions = self.sessions.write().await;
+        let mut sessions = self.sessions.write();
         let new_map = sessions_list
             .into_iter()
             .map(|session| (session.proposal.proposal_id, session))
@@ -346,8 +289,8 @@ where
         Ok(())
     }
 
-    async fn list_scopes(&self) -> Result<Option<Vec<Scope>>, ConsensusError> {
-        let sessions = self.sessions.read().await;
+    fn list_scopes(&self) -> Result<Option<Vec<Scope>>, ConsensusError> {
+        let sessions = self.sessions.read();
         let result = sessions.keys().cloned().collect::<Vec<Scope>>();
         if result.is_empty() {
             return Ok(None);
@@ -355,17 +298,16 @@ where
         Ok(Some(result))
     }
 
-    async fn update_session<R, F>(
+    fn update_session<R, F>(
         &self,
         scope: &Scope,
         proposal_id: u32,
         mutator: F,
     ) -> Result<R, ConsensusError>
     where
-        R: Send,
-        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError> + Send,
+        F: FnOnce(&mut ConsensusSession) -> Result<R, ConsensusError>,
     {
-        let mut sessions = self.sessions.write().await;
+        let mut sessions = self.sessions.write();
         let session = sessions
             .get_mut(scope)
             .and_then(|scope_sessions| scope_sessions.get_mut(&proposal_id))
@@ -375,15 +317,11 @@ where
         Ok(result)
     }
 
-    async fn update_scope_sessions<F>(
-        &self,
-        scope: &Scope,
-        mutator: F,
-    ) -> Result<(), ConsensusError>
+    fn update_scope_sessions<F>(&self, scope: &Scope, mutator: F) -> Result<(), ConsensusError>
     where
-        F: FnOnce(&mut Vec<ConsensusSession>) -> Result<(), ConsensusError> + Send,
+        F: FnOnce(&mut Vec<ConsensusSession>) -> Result<(), ConsensusError>,
     {
-        let mut sessions = self.sessions.write().await;
+        let mut sessions = self.sessions.write();
         let scope_sessions = sessions.entry(scope.clone()).or_default();
 
         let mut sessions_vec: Vec<ConsensusSession> = scope_sessions.values().cloned().collect();
@@ -403,37 +341,33 @@ where
         Ok(())
     }
 
-    async fn get_scope_config(&self, scope: &Scope) -> Result<Option<ScopeConfig>, ConsensusError> {
-        let configs = self.scope_configs.read().await;
+    fn get_scope_config(&self, scope: &Scope) -> Result<Option<ScopeConfig>, ConsensusError> {
+        let configs = self.scope_configs.read();
         Ok(configs.get(scope).cloned())
     }
 
-    async fn set_scope_config(
-        &self,
-        scope: &Scope,
-        config: ScopeConfig,
-    ) -> Result<(), ConsensusError> {
+    fn set_scope_config(&self, scope: &Scope, config: ScopeConfig) -> Result<(), ConsensusError> {
         config.validate()?;
-        let mut configs = self.scope_configs.write().await;
+        let mut configs = self.scope_configs.write();
         configs.insert(scope.clone(), config);
         Ok(())
     }
 
-    async fn delete_scope(&self, scope: &Scope) -> Result<(), ConsensusError> {
-        let mut sessions = self.sessions.write().await;
+    fn delete_scope(&self, scope: &Scope) -> Result<(), ConsensusError> {
+        let mut sessions = self.sessions.write();
         sessions.remove(scope);
         drop(sessions);
 
-        let mut configs = self.scope_configs.write().await;
+        let mut configs = self.scope_configs.write();
         configs.remove(scope);
         Ok(())
     }
 
-    async fn update_scope_config<F>(&self, scope: &Scope, updater: F) -> Result<(), ConsensusError>
+    fn update_scope_config<F>(&self, scope: &Scope, updater: F) -> Result<(), ConsensusError>
     where
-        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError> + Send,
+        F: FnOnce(&mut ScopeConfig) -> Result<(), ConsensusError>,
     {
-        let mut configs = self.scope_configs.write().await;
+        let mut configs = self.scope_configs.write();
         let config = configs.entry(scope.clone()).or_default();
         updater(config)?;
         config.validate()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ pub fn compute_vote_hash(vote: &Vote) -> Vec<u8> {
 /// This builds a vote that links to previous votes in the hashgraph structure.
 /// The vote is signed with the provided signer and includes all the necessary
 /// fields for validation (parent_hash, received_hash, vote_hash, signature).
-pub async fn build_vote<Signer: ConsensusSignatureScheme>(
+pub fn build_vote<Signer: ConsensusSignatureScheme>(
     proposal: &Proposal,
     user_vote: bool,
     signer: &Signer,
@@ -95,7 +95,7 @@ pub async fn build_vote<Signer: ConsensusSignatureScheme>(
 
     vote.vote_hash = compute_vote_hash(&vote);
     let vote_bytes = vote.encode_to_vec();
-    let signature = signer.sign(&vote_bytes).await?;
+    let signature = signer.sign(&vote_bytes)?;
     vote.signature = signature;
     Ok(vote)
 }

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -1,7 +1,9 @@
 use alloy::signers::local::PrivateKeySigner;
-use futures::future::join_all;
-use std::{sync::Arc, time::Duration};
-use tokio::{spawn, sync::Barrier, time::sleep};
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::Duration,
+};
 
 use hashgraph_like_consensus::{
     error::ConsensusError,
@@ -40,8 +42,8 @@ const EXPECTED_VOTERS_COUNT_5: u32 = 5;
 const EXPECTED_PROPOSALS_COUNT_5: u32 = 5;
 
 // Verifies 10 parallel votes succeed under gossipsub and reach consensus;
-#[tokio::test]
-async fn test_concurrent_vote_casting() {
+#[test]
+fn test_concurrent_vote_casting() {
     let storage = InMemoryConsensusStorage::<ScopeID>::new();
     let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
@@ -64,7 +66,6 @@ async fn test_concurrent_vote_casting() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal_id = proposal.proposal_id;
@@ -77,23 +78,20 @@ async fn test_concurrent_vote_casting() {
         let bus = bus.clone();
         let scope_clone = scope.clone();
         let barrier_clone = Arc::clone(&barrier);
-        let handle = spawn(async move {
-            barrier_clone.wait().await;
+        let handle = thread::spawn(move || {
+            barrier_clone.wait();
             let peer = peer_service(&storage, &bus, wrap(PrivateKeySigner::random()));
-            peer.cast_vote(&scope_clone, proposal_id, i % 2 == 0).await
+            peer.cast_vote(&scope_clone, proposal_id, i % 2 == 0)
         });
         handles.push(handle);
     }
 
-    let results: Vec<_> = join_all(handles).await;
+    let results: Vec<_> = handles.into_iter().map(|h| h.join()).collect();
     let success_count = results.iter().filter(|r| r.is_ok()).count();
     assert_eq!(success_count, 10, "All 10 unique votes should succeed");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
-    let result = owner
-        .storage()
-        .get_consensus_result(&scope, proposal_id)
-        .await;
+    thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
+    let result = owner.storage().get_consensus_result(&scope, proposal_id);
     assert!(
         result.is_ok(),
         "Consensus should be reached with concurrent votes"
@@ -101,8 +99,8 @@ async fn test_concurrent_vote_casting() {
 }
 
 // Test concurrent proposal creation and vote processing
-#[tokio::test]
-async fn test_concurrent_proposal_operations() {
+#[test]
+fn test_concurrent_proposal_operations() {
     let storage = InMemoryConsensusStorage::<ScopeID>::new();
     let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
@@ -112,28 +110,26 @@ async fn test_concurrent_proposal_operations() {
         let storage = storage.clone();
         let bus = bus.clone();
         let scope_clone = scope.clone();
-        let handle = spawn(async move {
+        let handle = thread::spawn(move || {
             let proposal_owner = peer_service(&storage, &bus, wrap(PrivateKeySigner::random()));
-            proposal_owner
-                .create_proposal_with_config(
-                    &scope_clone,
-                    CreateProposalRequest::new(
-                        format!("Proposal {i}"),
-                        PROPOSAL_PAYLOAD,
-                        proposal_owner.signer().identity().to_vec(),
-                        EXPECTED_VOTERS_COUNT_3,
-                        EXPIRATION,
-                        true,
-                    )
-                    .expect("valid proposal request"),
-                    Some(ConsensusConfig::gossipsub()),
+            proposal_owner.create_proposal_with_config(
+                &scope_clone,
+                CreateProposalRequest::new(
+                    format!("Proposal {i}"),
+                    PROPOSAL_PAYLOAD,
+                    proposal_owner.signer().identity().to_vec(),
+                    EXPECTED_VOTERS_COUNT_3,
+                    EXPIRATION,
+                    true,
                 )
-                .await
+                .expect("valid proposal request"),
+                Some(ConsensusConfig::gossipsub()),
+            )
         });
         handles.push(handle);
     }
 
-    let results: Vec<_> = join_all(handles).await;
+    let results: Vec<_> = handles.into_iter().map(|h| h.join()).collect();
     let success_count = results
         .iter()
         .filter(|r| r.is_ok() && r.as_ref().unwrap().is_ok())
@@ -145,8 +141,8 @@ async fn test_concurrent_proposal_operations() {
 }
 
 // Test that duplicate votes are properly rejected
-#[tokio::test]
-async fn test_concurrent_duplicate_vote_rejection() {
+#[test]
+fn test_concurrent_duplicate_vote_rejection() {
     let storage = InMemoryConsensusStorage::<ScopeID>::new();
     let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from(SCOPE);
@@ -170,7 +166,6 @@ async fn test_concurrent_duplicate_vote_rejection() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal_id = proposal.proposal_id;
@@ -183,11 +178,11 @@ async fn test_concurrent_duplicate_vote_rejection() {
     for _ in 0..EXPECTED_VOTERS_COUNT_5 {
         let voter = Arc::clone(&voter);
         let scope_clone = scope.clone();
-        let handle = spawn(async move { voter.cast_vote(&scope_clone, proposal_id, true).await });
+        let handle = thread::spawn(move || voter.cast_vote(&scope_clone, proposal_id, true));
         handles.push(handle);
     }
 
-    let results: Vec<_> = join_all(handles).await;
+    let results: Vec<_> = handles.into_iter().map(|h| h.join()).collect();
     let vote_results: Vec<_> = results
         .into_iter()
         .map(|r| r.expect("Task should complete"))

--- a/tests/consensus_service_tests.rs
+++ b/tests/consensus_service_tests.rs
@@ -1,10 +1,9 @@
-use alloy::signers::Signer;
+use alloy::signers::SignerSync;
 use alloy::signers::local::PrivateKeySigner;
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use prost::Message;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::time::timeout;
 
 use hashgraph_like_consensus::{
     error::ConsensusError,
@@ -17,7 +16,7 @@ use hashgraph_like_consensus::{
     utils::{build_vote, compute_vote_hash},
 };
 
-async fn cast_remote_vote(
+fn cast_remote_vote(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -27,13 +26,13 @@ async fn cast_remote_vote(
     hashgraph_like_consensus::protos::consensus::v1::Vote,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
-    let vote = build_vote(&proposal, choice, signer).await?;
-    service.process_incoming_vote(scope, vote.clone()).await?;
+    let proposal = service.storage().get_proposal(scope, proposal_id)?;
+    let vote = build_vote(&proposal, choice, signer)?;
+    service.process_incoming_vote(scope, vote.clone())?;
     Ok(vote)
 }
 
-async fn cast_remote_vote_and_get_proposal(
+fn cast_remote_vote_and_get_proposal(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -43,8 +42,8 @@ async fn cast_remote_vote_and_get_proposal(
     hashgraph_like_consensus::protos::consensus::v1::Proposal,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
-    service.storage().get_proposal(scope, proposal_id).await
+    cast_remote_vote(service, scope, proposal_id, choice, signer)?;
+    service.storage().get_proposal(scope, proposal_id)
 }
 
 fn make_service() -> DefaultConsensusService {
@@ -72,7 +71,7 @@ fn proposal_owner_from_signer(signer: &PrivateKeySigner) -> Vec<u8> {
     signer.address().as_slice().to_vec()
 }
 
-async fn setup_proposal(
+fn setup_proposal(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_owner: &PrivateKeySigner,
@@ -94,11 +93,10 @@ async fn setup_proposal(
             .expect("valid proposal request"),
             Some(consensus_config),
         )
-        .await
         .expect("proposal should be created")
 }
 
-async fn cast_vote_or_panic(
+fn cast_vote_or_panic(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -106,13 +104,11 @@ async fn cast_vote_or_panic(
     signer: PrivateKeySigner,
     msg: &str,
 ) {
-    cast_remote_vote(service, scope, proposal_id, choice, &wrap(signer))
-        .await
-        .expect(msg);
+    cast_remote_vote(service, scope, proposal_id, choice, &wrap(signer)).expect(msg);
 }
 
-#[tokio::test]
-async fn test_basic_consensus_flow() {
+#[test]
+fn test_basic_consensus_flow() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -131,7 +127,6 @@ async fn test_basic_consensus_flow() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -141,25 +136,19 @@ async fn test_basic_consensus_flow() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("proposal_owner vote should succeed");
 
     {
-        let active = service
-            .storage()
-            .get_active_proposals(&scope)
-            .await
-            .unwrap();
+        let active = service.storage().get_active_proposals(&scope).unwrap();
         assert_eq!(active.len(), 1);
     }
-    let stats = service.get_scope_stats(&scope).await;
+    let stats = service.get_scope_stats(&scope);
     assert_eq!(stats.total_sessions, 1);
 
     // Not enough votes yet -- consensus should not be reached
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         matches!(result, Err(ConsensusError::ConsensusNotReached)),
         "should not have reached consensus with only 1 vote"
@@ -173,7 +162,6 @@ async fn test_basic_consensus_flow() {
         VOTE_YES,
         &wrap(voter_two),
     )
-    .await
     .expect("second vote should succeed");
 
     let voter_three = PrivateKeySigner::random();
@@ -184,22 +172,20 @@ async fn test_basic_consensus_flow() {
         VOTE_YES,
         &wrap(voter_three),
     )
-    .await
     .expect("third vote should succeed");
 
     // Now consensus should be reached
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         result.is_ok(),
         "consensus should be reached with 3 YES votes"
     );
 }
 
-#[tokio::test]
-async fn test_multi_scope_isolation() {
+#[test]
+fn test_multi_scope_isolation() {
     let service = DefaultConsensusService::new_with_max_sessions(
         EthereumConsensusSigner::new(PrivateKeySigner::random()),
         5,
@@ -224,7 +210,6 @@ async fn test_multi_scope_isolation() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("scope1 proposal");
 
     cast_remote_vote_and_get_proposal(
@@ -234,7 +219,6 @@ async fn test_multi_scope_isolation() {
         VOTE_YES,
         &wrap(signer1),
     )
-    .await
     .expect("scope1 proposal_owner vote");
 
     let proposal_2 = service
@@ -251,7 +235,6 @@ async fn test_multi_scope_isolation() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("scope2 proposal");
 
     cast_remote_vote_and_get_proposal(
@@ -261,39 +244,30 @@ async fn test_multi_scope_isolation() {
         VOTE_YES,
         &wrap(signer2),
     )
-    .await
     .expect("scope2 proposal_owner vote");
 
     {
-        let active = service
-            .storage()
-            .get_active_proposals(&scope1)
-            .await
-            .unwrap();
+        let active = service.storage().get_active_proposals(&scope1).unwrap();
         assert_eq!(active.len(), 1);
     }
     {
-        let active = service
-            .storage()
-            .get_active_proposals(&scope2)
-            .await
-            .unwrap();
+        let active = service.storage().get_active_proposals(&scope2).unwrap();
         assert_eq!(active.len(), 0); // scope2 reached consensus
     }
 
-    let stats1 = service.get_scope_stats(&scope1).await;
+    let stats1 = service.get_scope_stats(&scope1);
     assert_eq!(stats1.total_sessions, 1);
     assert_eq!(stats1.active_sessions, 1);
 
-    let stats2 = service.get_scope_stats(&scope2).await;
+    let stats2 = service.get_scope_stats(&scope2);
     assert_eq!(stats2.total_sessions, 1);
     assert_eq!(stats2.active_sessions, 0);
 }
 
-#[tokio::test]
-async fn test_consensus_threshold_emits_event() {
+#[test]
+fn test_consensus_threshold_emits_event() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -311,7 +285,6 @@ async fn test_consensus_threshold_emits_event() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     cast_remote_vote(
@@ -321,7 +294,6 @@ async fn test_consensus_threshold_emits_event() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("proposal_owner vote");
 
     for _ in 0..3 {
@@ -333,13 +305,12 @@ async fn test_consensus_threshold_emits_event() {
             VOTE_YES,
             &wrap(signer),
         )
-        .await
         .expect("additional vote");
     }
 
     let proposal_id = proposal.proposal_id;
-    let result = timeout(Duration::from_secs(5), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let result = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(5)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -352,16 +323,14 @@ async fn test_consensus_threshold_emits_event() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("consensus event missing");
 
     assert!(result);
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_already_reached() {
+#[test]
+fn test_handle_consensus_timeout_already_reached() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -374,8 +343,7 @@ async fn test_handle_consensus_timeout_already_reached() {
         EXPECTED_VOTERS_COUNT_2,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     // Cast votes to reach consensus
     cast_vote_or_panic(
@@ -385,8 +353,7 @@ async fn test_handle_consensus_timeout_already_reached() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     let voter2 = PrivateKeySigner::random();
     cast_vote_or_panic(
@@ -396,25 +363,23 @@ async fn test_handle_consensus_timeout_already_reached() {
         VOTE_YES,
         voter2,
         "second vote",
-    )
-    .await;
+    );
 
     // Wait a bit to ensure consensus is reached
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::thread::sleep(Duration::from_millis(100));
 
     // Now call handle_consensus_timeout - should return the already reached consensus
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should return consensus result");
 
     assert!(result, "should return true (YES consensus)");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_reaches_consensus() {
+#[test]
+fn test_handle_consensus_timeout_reaches_consensus() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -426,8 +391,7 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
         EXPECTED_VOTERS_COUNT_3,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     // Cast 2 YES votes (need 2 for threshold with 3 expected voters)
     cast_vote_or_panic(
@@ -437,8 +401,7 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     let voter2 = PrivateKeySigner::random();
     cast_vote_or_panic(
@@ -448,20 +411,18 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
         VOTE_YES,
         voter2,
         "second vote",
-    )
-    .await;
+    );
 
     // Call handle_consensus_timeout - should calculate consensus and reach it
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach consensus");
 
     assert!(result, "should return true (YES consensus)");
 
     // Verify event was emitted
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -474,18 +435,16 @@ async fn test_handle_consensus_timeout_reaches_consensus() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("consensus event should be emitted");
 
     assert!(event_received, "event should indicate YES consensus");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes() {
+#[test]
+fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
 
     let yes_voter = PrivateKeySigner::random();
@@ -499,8 +458,7 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
         EXPECTED_VOTERS_COUNT_4,
         false,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     cast_vote_or_panic(
         &service,
@@ -509,8 +467,7 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
         true,
         yes_voter,
         "YES vote should succeed",
-    )
-    .await;
+    );
 
     cast_vote_or_panic(
         &service,
@@ -519,8 +476,7 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
         false,
         no_voter_1,
         "first NO vote should succeed",
-    )
-    .await;
+    );
 
     cast_vote_or_panic(
         &service,
@@ -529,18 +485,16 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
         false,
         no_voter_2,
         "second NO vote should succeed",
-    )
-    .await;
+    );
 
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach consensus at timeout");
 
     assert!(!result, "should return false (NO consensus)");
 
-    let event_result = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_result = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -553,18 +507,16 @@ async fn test_handle_consensus_timeout_reaches_no_consensus_with_multiple_votes(
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("consensus event should be emitted");
 
     assert!(!event_result, "event should indicate NO consensus");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
+#[test]
+fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -576,8 +528,7 @@ async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
         EXPECTED_VOTERS_COUNT_4,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     // Cast 1 YES vote (3 silent peers counted as YES at timeout → 4 YES total)
     cast_vote_or_panic(
@@ -587,20 +538,18 @@ async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     // At timeout with liveness=true, silent peers count as YES → consensus reached
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach consensus with silent peers as YES");
 
     assert!(result, "should return true (YES consensus)");
 
     // Verify ConsensusReached event was emitted
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -613,9 +562,7 @@ async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("ConsensusReached event should be emitted");
 
     assert!(event_received, "event should indicate YES consensus");
@@ -624,15 +571,14 @@ async fn test_handle_consensus_timeout_resolves_with_liveness_yes() {
     let consensus_result = service
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("consensus result should be available");
     assert!(consensus_result, "consensus result should be true");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_insufficient_votes() {
+#[test]
+fn test_handle_consensus_timeout_insufficient_votes() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -644,8 +590,7 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
         EXPECTED_VOTERS_COUNT_4,
         false,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     // Cast 2 YES votes (2 silent count as NO → 2 YES, 2 NO → tied → no consensus)
     cast_vote_or_panic(
@@ -655,8 +600,7 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     let voter2 = PrivateKeySigner::random();
     cast_vote_or_panic(
@@ -666,13 +610,11 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
         VOTE_YES,
         voter2,
         "second vote",
-    )
-    .await;
+    );
 
     // Call handle_consensus_timeout - should fail (tied votes, no majority)
     let err = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect_err("should fail with insufficient votes");
 
     assert!(
@@ -681,8 +623,8 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
     );
 
     // Verify ConsensusFailed event was emitted
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusFailed {
                     proposal_id: event_proposal_id,
@@ -694,28 +636,21 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
             }
         }
         false
-    })
-    .await
-    .expect("event timeout");
+    })();
 
     assert!(event_received, "ConsensusFailed event should be emitted");
 
     // Verify session is marked as Failed via get_consensus_result
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         matches!(result, Err(ConsensusError::ConsensusFailed)),
         "session should be in Failed state"
     );
 
     {
-        let active = service
-            .storage()
-            .get_active_proposals(&scope)
-            .await
-            .unwrap();
+        let active = service.storage().get_active_proposals(&scope).unwrap();
         assert!(
             active.is_empty(),
             "proposal should not be in active proposals"
@@ -723,10 +658,10 @@ async fn test_handle_consensus_timeout_insufficient_votes() {
     }
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_no_votes_liveness_true() {
+#[test]
+fn test_handle_consensus_timeout_no_votes_liveness_true() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -739,19 +674,17 @@ async fn test_handle_consensus_timeout_no_votes_liveness_true() {
         EXPECTED_VOTERS_COUNT_3,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach consensus with silent peers as YES");
 
     assert!(result, "should return true (all silent peers as YES)");
 
     // Verify ConsensusReached event was emitted
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -764,18 +697,16 @@ async fn test_handle_consensus_timeout_no_votes_liveness_true() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("ConsensusReached event should be emitted");
 
     assert!(event_received, "event should indicate YES consensus");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_no_votes_liveness_false() {
+#[test]
+fn test_handle_consensus_timeout_no_votes_liveness_false() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
 
@@ -788,19 +719,17 @@ async fn test_handle_consensus_timeout_no_votes_liveness_false() {
         EXPECTED_VOTERS_COUNT_3,
         false,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach NO consensus with silent peers as NO");
 
     assert!(!result, "should return false (all silent peers as NO)");
 
     // Verify ConsensusReached event was emitted
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -813,18 +742,16 @@ async fn test_handle_consensus_timeout_no_votes_liveness_false() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("ConsensusReached event should be emitted");
 
     assert!(!event_received, "event should indicate NO consensus");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
+#[test]
+fn test_handle_consensus_timeout_reaches_consensus_p2p() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from("scope_p2p_reaches_consensus");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -835,8 +762,7 @@ async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
         EXPECTED_VOTERS_COUNT_3,
         true,
         ConsensusConfig::p2p(),
-    )
-    .await;
+    );
 
     cast_vote_or_panic(
         &service,
@@ -845,8 +771,7 @@ async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     let voter2 = PrivateKeySigner::random();
     cast_vote_or_panic(
@@ -856,18 +781,16 @@ async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
         VOTE_YES,
         voter2,
         "second vote",
-    )
-    .await;
+    );
 
     let result = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect("should reach consensus");
 
     assert!(result, "should return true (YES consensus)");
 
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusReached {
                     proposal_id: event_proposal_id,
@@ -880,18 +803,16 @@ async fn test_handle_consensus_timeout_reaches_consensus_p2p() {
             }
         }
         None
-    })
-    .await
-    .expect("event timeout")
+    })()
     .expect("consensus event should be emitted");
 
     assert!(event_received, "event should indicate YES consensus");
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
+#[test]
+fn test_handle_consensus_timeout_insufficient_votes_p2p() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from("scope_p2p_insufficient_votes");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -902,8 +823,7 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
         EXPECTED_VOTERS_COUNT_4,
         false,
         ConsensusConfig::p2p(),
-    )
-    .await;
+    );
 
     // Cast 2 YES votes (2 silent count as NO → 2 YES, 2 NO → tied → no consensus)
     cast_vote_or_panic(
@@ -913,8 +833,7 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
         VOTE_YES,
         proposal_owner,
         "first vote",
-    )
-    .await;
+    );
 
     let voter2 = PrivateKeySigner::random();
     cast_vote_or_panic(
@@ -924,12 +843,10 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
         VOTE_YES,
         voter2,
         "second vote",
-    )
-    .await;
+    );
 
     let err = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect_err("should fail with insufficient votes");
 
     assert!(
@@ -937,8 +854,8 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
         "should return InsufficientVotesAtTimeout error"
     );
 
-    let event_received = timeout(Duration::from_secs(1), async {
-        while let Ok((event_scope, event)) = events.recv().await {
+    let event_received = (|| {
+        while let Ok((event_scope, event)) = events.recv_timeout(Duration::from_secs(1)) {
             if event_scope == scope
                 && let ConsensusEvent::ConsensusFailed {
                     proposal_id: event_proposal_id,
@@ -950,15 +867,13 @@ async fn test_handle_consensus_timeout_insufficient_votes_p2p() {
             }
         }
         false
-    })
-    .await
-    .expect("event timeout");
+    })();
 
     assert!(event_received, "ConsensusFailed event should be emitted");
 }
 
-#[tokio::test]
-async fn test_cast_vote_rejects_same_voter_twice() {
+#[test]
+fn test_cast_vote_rejects_same_voter_twice() {
     // Service-side dedup: cast_vote pre-checks the held signer's identity
     // against the session's votes map and returns UserAlreadyVoted.
     let proposal_owner = PrivateKeySigner::random();
@@ -980,17 +895,14 @@ async fn test_cast_vote_rejects_same_voter_twice() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     service
         .cast_vote(&scope, proposal.proposal_id, VOTE_YES)
-        .await
         .expect("first vote should succeed");
 
     let err = service
         .cast_vote(&scope, proposal.proposal_id, VOTE_YES)
-        .await
         .expect_err("second vote from same voter should fail");
 
     assert!(
@@ -999,8 +911,8 @@ async fn test_cast_vote_rejects_same_voter_twice() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_proposal_rejects_duplicate_proposal() {
+#[test]
+fn test_process_incoming_proposal_rejects_duplicate_proposal() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1019,12 +931,10 @@ async fn test_process_incoming_proposal_rejects_duplicate_proposal() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let err = service
         .process_incoming_proposal(&scope, proposal)
-        .await
         .expect_err("duplicate proposal should be rejected");
 
     assert!(
@@ -1033,8 +943,8 @@ async fn test_process_incoming_proposal_rejects_duplicate_proposal() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_vote_rejects_unknown_session() {
+#[test]
+fn test_process_incoming_vote_rejects_unknown_session() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
 
@@ -1053,7 +963,6 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let unknown_proposal_id = proposal.proposal_id.wrapping_add(1);
@@ -1065,7 +974,6 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
         VOTE_YES,
         &wrap(vote_owner.clone()),
     )
-    .await
     .expect("valid signed vote");
 
     let mut invalid_vote = vote;
@@ -1074,15 +982,13 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
     invalid_vote.signature.clear();
     let vote_bytes = invalid_vote.encode_to_vec();
     invalid_vote.signature = vote_owner
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("vote should be resignable")
         .as_bytes()
         .to_vec();
 
     let err = service
         .process_incoming_vote(&scope, invalid_vote)
-        .await
         .expect_err("vote for unknown proposal should fail");
 
     assert!(
@@ -1091,14 +997,13 @@ async fn test_process_incoming_vote_rejects_unknown_session() {
     );
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_rejects_unknown_session() {
+#[test]
+fn test_handle_consensus_timeout_rejects_unknown_session() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
 
     let err = service
         .handle_consensus_timeout(&scope, u32::MAX)
-        .await
         .expect_err("timeout handling for unknown proposal should fail");
 
     assert!(
@@ -1107,8 +1012,8 @@ async fn test_handle_consensus_timeout_rejects_unknown_session() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_proposal_rejects_expired_proposal() {
+#[test]
+fn test_process_incoming_proposal_rejects_expired_proposal() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1124,11 +1029,10 @@ async fn test_process_incoming_proposal_rejects_expired_proposal() {
     .expect("valid proposal request");
     let proposal = request.into_proposal().expect("proposal should be created");
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    std::thread::sleep(Duration::from_secs(2));
 
     let err = service
         .process_incoming_proposal(&scope, proposal)
-        .await
         .expect_err("expired incoming proposal should fail");
 
     assert!(
@@ -1137,8 +1041,8 @@ async fn test_process_incoming_proposal_rejects_expired_proposal() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
+#[test]
+fn test_process_incoming_vote_rejects_invalid_vote_hash() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1157,7 +1061,6 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1167,18 +1070,15 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
-        .await
-        .expect("valid vote should be built");
+    let mut vote =
+        build_vote(&proposal, VOTE_YES, &wrap(voter)).expect("valid vote should be built");
     vote.vote_hash = vec![1; 32];
 
     let err = service
         .process_incoming_vote(&scope, vote)
-        .await
         .expect_err("tampered vote hash should fail");
 
     assert!(
@@ -1187,8 +1087,8 @@ async fn test_process_incoming_vote_rejects_invalid_vote_hash() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
+#[test]
+fn test_process_incoming_vote_rejects_invalid_vote_signature() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1207,7 +1107,6 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1217,24 +1116,20 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
         VOTE_YES,
         &wrap(proposal_owner.clone()),
     )
-    .await
     .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
-        .await
-        .expect("valid vote should be built");
+    let mut vote =
+        build_vote(&proposal, VOTE_YES, &wrap(voter)).expect("valid vote should be built");
     let wrong_signer = PrivateKeySigner::random();
     let vote_bytes = vote.encode_to_vec();
     let wrong_sig = wrong_signer
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("wrong signer should sign");
     vote.signature = wrong_sig.as_bytes().to_vec();
 
     let err = service
         .process_incoming_vote(&scope, vote)
-        .await
         .expect_err("tampered signature should fail");
 
     assert!(
@@ -1243,8 +1138,8 @@ async fn test_process_incoming_vote_rejects_invalid_vote_signature() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
+#[test]
+fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1263,7 +1158,6 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1273,16 +1167,13 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
         VOTE_YES,
         &wrap(proposal_owner.clone()),
     )
-    .await
     .expect("first owner vote should succeed");
 
     let duplicate_vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
-        .await
         .expect("duplicate vote should be signable");
 
     let err = service
         .process_incoming_vote(&scope, duplicate_vote)
-        .await
         .expect_err("duplicate vote owner should fail");
 
     assert!(
@@ -1291,8 +1182,8 @@ async fn test_process_incoming_vote_rejects_duplicate_vote_owner() {
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
+#[test]
+fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1311,7 +1202,6 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1321,27 +1211,23 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote should succeed");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
-        .await
-        .expect("valid vote should be built");
+    let mut vote =
+        build_vote(&proposal, VOTE_YES, &wrap(voter.clone())).expect("valid vote should be built");
     vote.timestamp = proposal.expiration_timestamp.saturating_add(1);
     vote.vote_hash = compute_vote_hash(&vote);
     vote.signature.clear();
     let vote_bytes = vote.encode_to_vec();
     vote.signature = voter
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("vote should be resignable")
         .as_bytes()
         .to_vec();
 
     let err = service
         .process_incoming_vote(&scope, vote)
-        .await
         .expect_err("expired vote timestamp should fail");
 
     assert!(
@@ -1350,8 +1236,8 @@ async fn test_process_incoming_vote_rejects_expired_vote_timestamp() {
     );
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
+#[test]
+fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1371,7 +1257,6 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     cast_remote_vote(
@@ -1381,7 +1266,6 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote should succeed");
 
     let voter2 = PrivateKeySigner::random();
@@ -1392,12 +1276,10 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote should succeed");
 
     let err_first = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect_err("first timeout should fail consensus");
     assert!(matches!(
         err_first,
@@ -1406,7 +1288,6 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
 
     let err_second = service
         .handle_consensus_timeout(&scope, proposal.proposal_id)
-        .await
         .expect_err("second timeout should keep failed consensus");
     assert!(matches!(
         err_second,
@@ -1415,19 +1296,17 @@ async fn test_handle_consensus_timeout_is_idempotent_for_failed_session() {
 
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(matches!(result, Err(ConsensusError::ConsensusFailed)));
 }
 
-#[tokio::test]
-async fn test_handle_consensus_timeout_rejects_unknown_scope() {
+#[test]
+fn test_handle_consensus_timeout_rejects_unknown_scope() {
     let service = make_service();
     let unknown_scope = ScopeID::from("unknown_scope");
 
     let err = service
         .handle_consensus_timeout(&unknown_scope, 1)
-        .await
         .expect_err("unknown scope timeout handling should fail");
 
     assert!(
@@ -1436,10 +1315,10 @@ async fn test_handle_consensus_timeout_rejects_unknown_scope() {
     );
 }
 
-#[tokio::test]
-async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
+#[test]
+fn test_cast_vote_still_active_does_not_emit_consensus_event() {
     let service = make_service();
-    let mut events = service.event_bus().subscribe();
+    let events = service.event_bus().subscribe();
     let scope = ScopeID::from("still_active_no_event_scope");
     let proposal_owner = PrivateKeySigner::random();
 
@@ -1450,8 +1329,7 @@ async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
         EXPECTED_VOTERS_COUNT_4,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     // One vote is insufficient for n=4; transition should remain StillActive.
     cast_remote_vote(
@@ -1461,18 +1339,17 @@ async fn test_cast_vote_still_active_does_not_emit_consensus_event() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should succeed");
 
-    let no_event = timeout(Duration::from_millis(150), events.recv()).await;
+    let no_event = events.recv_timeout(Duration::from_millis(150));
     assert!(
         no_event.is_err(),
         "no terminal consensus event should be emitted while session is still active"
     );
 }
 
-#[tokio::test]
-async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_expiration_not_after_timestamp()
+#[test]
+fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_expiration_not_after_timestamp()
  {
     let service = make_service();
     let scope = ScopeID::from("resolve_config_base_timeout_scope");
@@ -1501,13 +1378,11 @@ async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_ex
 
     service
         .process_incoming_proposal(&scope, incoming.clone())
-        .await
         .expect("incoming proposal should be accepted");
 
     let resolved = service
         .storage()
         .get_proposal_config(&scope, incoming.proposal_id)
-        .await
         .expect("resolved config");
 
     assert_eq!(
@@ -1521,8 +1396,8 @@ async fn test_process_incoming_proposal_resolve_config_uses_base_timeout_when_ex
     );
 }
 
-#[tokio::test]
-async fn test_get_reached_proposals_with_consensus() {
+#[test]
+fn test_get_reached_proposals_with_consensus() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1542,7 +1417,6 @@ async fn test_get_reached_proposals_with_consensus() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     // Cast vote to reach consensus
@@ -1553,15 +1427,10 @@ async fn test_get_reached_proposals_with_consensus() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should succeed");
 
     // Get reached proposals
-    let reached_map = service
-        .storage()
-        .get_reached_proposals(&scope)
-        .await
-        .unwrap();
+    let reached_map = service.storage().get_reached_proposals(&scope).unwrap();
 
     assert_eq!(
         reached_map.len(),
@@ -1579,8 +1448,8 @@ async fn test_get_reached_proposals_with_consensus() {
     );
 }
 
-#[tokio::test]
-async fn test_get_reached_proposals_no_consensus() {
+#[test]
+fn test_get_reached_proposals_no_consensus() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner = PrivateKeySigner::random();
@@ -1600,17 +1469,12 @@ async fn test_get_reached_proposals_no_consensus() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     // Don't cast enough votes - proposal remains active
 
     // Get reached proposals
-    let reached = service
-        .storage()
-        .get_reached_proposals(&scope)
-        .await
-        .unwrap();
+    let reached = service.storage().get_reached_proposals(&scope).unwrap();
 
     assert!(
         reached.is_empty(),
@@ -1618,8 +1482,8 @@ async fn test_get_reached_proposals_no_consensus() {
     );
 }
 
-#[tokio::test]
-async fn test_get_reached_proposals_mixed_states() {
+#[test]
+fn test_get_reached_proposals_mixed_states() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE1_NAME);
     let proposal_owner1 = PrivateKeySigner::random();
@@ -1641,7 +1505,6 @@ async fn test_get_reached_proposals_mixed_states() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     cast_remote_vote(
@@ -1651,7 +1514,6 @@ async fn test_get_reached_proposals_mixed_states() {
         true,
         &wrap(proposal_owner1),
     )
-    .await
     .expect("vote should succeed");
 
     // Create proposal 2 that reaches consensus (NO)
@@ -1669,7 +1531,6 @@ async fn test_get_reached_proposals_mixed_states() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     cast_remote_vote(
@@ -1679,7 +1540,6 @@ async fn test_get_reached_proposals_mixed_states() {
         false,
         &wrap(proposal_owner2),
     )
-    .await
     .expect("vote should succeed");
 
     // Create proposal 3 that remains active (doesn't reach consensus)
@@ -1697,17 +1557,12 @@ async fn test_get_reached_proposals_mixed_states() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     // Don't cast enough votes for proposal3
 
     // Get reached proposals
-    let reached_map = service
-        .storage()
-        .get_reached_proposals(&scope)
-        .await
-        .unwrap();
+    let reached_map = service.storage().get_reached_proposals(&scope).unwrap();
 
     assert_eq!(
         reached_map.len(),
@@ -1738,8 +1593,8 @@ async fn test_get_reached_proposals_mixed_states() {
     );
 }
 
-#[tokio::test]
-async fn test_get_reached_proposals_nonexistent_scope() {
+#[test]
+fn test_get_reached_proposals_nonexistent_scope() {
     let service = make_service();
     let nonexistent_scope = ScopeID::from("nonexistent");
 
@@ -1747,7 +1602,6 @@ async fn test_get_reached_proposals_nonexistent_scope() {
     let reached = service
         .storage()
         .get_reached_proposals(&nonexistent_scope)
-        .await
         .unwrap();
 
     assert!(
@@ -1756,12 +1610,12 @@ async fn test_get_reached_proposals_nonexistent_scope() {
     );
 }
 
-#[tokio::test]
-async fn test_unknown_scope_queries_stats_and_active_proposals() {
+#[test]
+fn test_unknown_scope_queries_stats_and_active_proposals() {
     let service = make_service();
     let unknown_scope = ScopeID::from("unknown_scope");
 
-    let stats = service.get_scope_stats(&unknown_scope).await;
+    let stats = service.get_scope_stats(&unknown_scope);
     assert_eq!(
         stats.total_sessions, 0,
         "unknown scope should have zero total sessions"
@@ -1782,7 +1636,6 @@ async fn test_unknown_scope_queries_stats_and_active_proposals() {
     let active = service
         .storage()
         .get_active_proposals(&unknown_scope)
-        .await
         .unwrap();
     assert!(
         active.is_empty(),
@@ -1790,8 +1643,8 @@ async fn test_unknown_scope_queries_stats_and_active_proposals() {
     );
 }
 
-#[tokio::test]
-async fn test_delete_scope_cleans_up_all_state() {
+#[test]
+fn test_delete_scope_cleans_up_all_state() {
     let service = make_service();
     let scope = ScopeID::from("delete_scope_test");
     let proposal_owner = PrivateKeySigner::random();
@@ -1804,8 +1657,7 @@ async fn test_delete_scope_cleans_up_all_state() {
         EXPECTED_VOTERS_COUNT_1,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     cast_remote_vote(
         &service,
@@ -1814,22 +1666,16 @@ async fn test_delete_scope_cleans_up_all_state() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should succeed");
 
     // Verify state exists
     let consensus_result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(consensus_result.is_ok(), "consensus should be reached");
 
     {
-        let reached = service
-            .storage()
-            .get_reached_proposals(&scope)
-            .await
-            .unwrap();
+        let reached = service.storage().get_reached_proposals(&scope).unwrap();
         assert!(
             !reached.is_empty(),
             "should have reached proposals before delete"
@@ -1840,25 +1686,16 @@ async fn test_delete_scope_cleans_up_all_state() {
     service
         .storage()
         .delete_scope(&scope)
-        .await
         .expect("delete_scope should succeed");
 
     // 3. Verify all state is gone
-    let active = service
-        .storage()
-        .get_active_proposals(&scope)
-        .await
-        .unwrap();
+    let active = service.storage().get_active_proposals(&scope).unwrap();
     assert!(
         active.is_empty(),
         "get_active_proposals should return empty vec after delete"
     );
 
-    let reached = service
-        .storage()
-        .get_reached_proposals(&scope)
-        .await
-        .unwrap();
+    let reached = service.storage().get_reached_proposals(&scope).unwrap();
     assert!(
         reached.is_empty(),
         "get_reached_proposals should return empty map after delete"
@@ -1866,8 +1703,7 @@ async fn test_delete_scope_cleans_up_all_state() {
 
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         matches!(result, Err(ConsensusError::SessionNotFound)),
         "get_consensus_result should return SessionNotFound after delete"
@@ -1882,8 +1718,7 @@ async fn test_delete_scope_cleans_up_all_state() {
         EXPECTED_VOTERS_COUNT_1,
         true,
         ConsensusConfig::gossipsub(),
-    )
-    .await;
+    );
 
     cast_remote_vote(
         &service,
@@ -1892,24 +1727,22 @@ async fn test_delete_scope_cleans_up_all_state() {
         VOTE_YES,
         &wrap(new_owner),
     )
-    .await
     .expect("vote on new proposal should succeed");
 
     let new_result = service
         .storage()
         .get_consensus_result(&scope, new_proposal.proposal_id)
-        .await
         .expect("new consensus should be reachable");
     assert!(new_result, "new proposal should reach YES consensus");
 }
 
-#[tokio::test]
-async fn test_delete_scope_on_unknown_scope_is_ok() {
+#[test]
+fn test_delete_scope_on_unknown_scope_is_ok() {
     let service = make_service();
     let unknown_scope = ScopeID::from("never_existed");
 
     // Deleting a scope that was never created should not error
-    let result = service.storage().delete_scope(&unknown_scope).await;
+    let result = service.storage().delete_scope(&unknown_scope);
     assert!(
         result.is_ok(),
         "delete_scope on unknown scope should succeed"

--- a/tests/custom_scheme_tests.rs
+++ b/tests/custom_scheme_tests.rs
@@ -49,7 +49,7 @@ impl ConsensusSignatureScheme for StubSigner {
         &self.identity
     }
 
-    async fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, ConsensusSchemeError> {
         Ok(Self::expected_signature(&self.identity, payload))
     }
 
@@ -84,8 +84,8 @@ fn peer_service(
     StubService::new_with_components(storage.clone(), bus.clone(), signer, 10)
 }
 
-#[tokio::test]
-async fn stub_scheme_reaches_consensus_without_ethereum_types() {
+#[test]
+fn stub_scheme_reaches_consensus_without_ethereum_types() {
     let storage = InMemoryConsensusStorage::<ScopeID>::new();
     let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from("stub-scope");
@@ -108,26 +108,21 @@ async fn stub_scheme_reaches_consensus_without_ethereum_types() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     owner
         .cast_vote(&scope, proposal.proposal_id, true)
-        .await
         .expect("owner vote");
     voter_two
         .cast_vote(&scope, proposal.proposal_id, true)
-        .await
         .expect("voter two");
     voter_three
         .cast_vote(&scope, proposal.proposal_id, true)
-        .await
         .expect("voter three");
 
     let session = owner
         .storage()
         .get_session(&scope, proposal.proposal_id)
-        .await
         .expect("get session")
         .expect("session exists");
     assert!(
@@ -136,8 +131,8 @@ async fn stub_scheme_reaches_consensus_without_ethereum_types() {
     );
 }
 
-#[tokio::test]
-async fn stub_scheme_rejects_forged_signature() {
+#[test]
+fn stub_scheme_rejects_forged_signature() {
     let storage = InMemoryConsensusStorage::<ScopeID>::new();
     let bus = BroadcastEventBus::<ScopeID>::default();
     let scope = ScopeID::from("stub-scope-forge");
@@ -159,16 +154,14 @@ async fn stub_scheme_rejects_forged_signature() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
-    let mut vote = build_vote(&proposal, true, &voter).await.expect("vote");
+    let mut vote = build_vote(&proposal, true, &voter).expect("vote");
     // Tamper with the signature so verify() returns false.
     vote.signature.iter_mut().for_each(|b| *b ^= 0xFF);
 
     let err = owner
         .process_incoming_vote(&scope, vote)
-        .await
         .expect_err("forged signature must be rejected");
     assert!(
         matches!(

--- a/tests/network_gossip_tests.rs
+++ b/tests/network_gossip_tests.rs
@@ -1,5 +1,6 @@
 use alloy::signers::local::PrivateKeySigner;
-use tokio::time::{Duration, sleep};
+use std::thread;
+use std::time::Duration;
 
 use hashgraph_like_consensus::{
     error::ConsensusError, scope::ScopeID, service::DefaultConsensusService,
@@ -7,7 +8,7 @@ use hashgraph_like_consensus::{
     types::CreateProposalRequest, utils::build_vote,
 };
 
-async fn cast_remote_vote(
+fn cast_remote_vote(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -17,9 +18,9 @@ async fn cast_remote_vote(
     hashgraph_like_consensus::protos::consensus::v1::Vote,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
-    let vote = build_vote(&proposal, choice, signer).await?;
-    service.process_incoming_vote(scope, vote.clone()).await?;
+    let proposal = service.storage().get_proposal(scope, proposal_id)?;
+    let vote = build_vote(&proposal, choice, signer)?;
+    service.process_incoming_vote(scope, vote.clone())?;
     Ok(vote)
 }
 
@@ -42,8 +43,8 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
 
 /// Peer A creates a proposal, gossips it to peer B, both vote YES,
 /// gossip votes back/forth, and both peers converge to Ok(true) consensus result.
-#[tokio::test]
-async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
+#[test]
+fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
     let peer_a = make_service();
     let peer_b = make_service();
     let scope = ScopeID::from(SCOPE);
@@ -63,44 +64,36 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("peer_a proposal");
 
     // Gossip proposal to peer_b (decentralized: each peer stores locally).
     peer_b
         .process_incoming_proposal(&scope, proposal.clone())
-        .await
         .expect("peer_b accepts proposal");
 
     // Peer A votes YES, gossip vote to peer B.
     let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
-        .await
         .expect("peer_a vote");
     peer_b
         .process_incoming_vote(&scope, vote_a)
-        .await
         .expect("peer_b accepts peer_a vote");
 
     // Peer B votes YES, gossip vote to peer A.
     let owner_b = PrivateKeySigner::random();
     let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(owner_b))
-        .await
         .expect("peer_b vote");
     peer_a
         .process_incoming_vote(&scope, vote_b)
-        .await
         .expect("peer_a accepts peer_b vote");
 
     // Both peers should converge to the same consensus result.
     let res_a = peer_a
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("peer_a has consensus");
     let res_b = peer_b
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("peer_b has consensus");
 
     assert!(res_a);
@@ -109,8 +102,8 @@ async fn test_two_peers_gossip_reaches_unanimous_yes_for_n2() {
 
 /// Three peers, and peer C receives votes in a different order,
 /// but still converges to the same YES result.
-#[tokio::test]
-async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
+#[test]
+fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
     let peer_a = make_service();
     let peer_b = make_service();
     let peer_c = make_service();
@@ -131,62 +124,50 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("peer_a proposal");
 
     // Gossip proposal to other peers
     peer_b
         .process_incoming_proposal(&scope, proposal.clone())
-        .await
         .expect("peer_b accepts proposal");
     peer_c
         .process_incoming_proposal(&scope, proposal.clone())
-        .await
         .expect("peer_c accepts proposal");
 
     // Two YES votes are sufficient for n=3 with threshold 2/3 and majority YES.
     let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
-        .await
         .expect("peer_a vote");
     let owner_b = PrivateKeySigner::random();
     let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(owner_b))
-        .await
         .expect("peer_b vote");
 
     // Deliver to peer_c out-of-order (vote_b then vote_a).
     peer_c
         .process_incoming_vote(&scope, vote_b.clone())
-        .await
         .expect("peer_c accepts vote_b");
     peer_c
         .process_incoming_vote(&scope, vote_a.clone())
-        .await
         .expect("peer_c accepts vote_a");
 
     // Deliver to peer_a and peer_b (in-order doesn't matter either).
     peer_a
         .process_incoming_vote(&scope, vote_b)
-        .await
         .expect("peer_a accepts vote_b");
     peer_b
         .process_incoming_vote(&scope, vote_a)
-        .await
         .expect("peer_b accepts vote_a");
 
     let res_a = peer_a
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("peer_a has consensus");
     let res_b = peer_b
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("peer_b has consensus");
     let res_c = peer_c
         .storage()
         .get_consensus_result(&scope, proposal.proposal_id)
-        .await
         .expect("peer_c has consensus");
 
     assert!(res_a);
@@ -198,8 +179,8 @@ async fn test_three_peers_gossip_converges_with_out_of_order_delivery() {
 /// All peers should converge to the same "failed" state.
 /// With liveness=false and 2 YES votes out of 4, silent peers count as NO at timeout,
 /// resulting in a 2 YES / 2 NO tie → no consensus.
-#[tokio::test]
-async fn test_multi_peer_timeout_task_converges_to_failed() {
+#[test]
+fn test_multi_peer_timeout_task_converges_to_failed() {
     let peer_a = make_service();
     let peer_b = make_service();
     let peer_c = make_service();
@@ -222,41 +203,32 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("peer_a proposal");
 
     peer_b
         .process_incoming_proposal(&scope, proposal.clone())
-        .await
         .expect("peer_b accepts proposal");
     peer_c
         .process_incoming_proposal(&scope, proposal.clone())
-        .await
         .expect("peer_c accepts proposal");
 
     // 2 YES votes total.
     let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
-        .await
         .expect("peer_a vote");
     peer_b
         .process_incoming_vote(&scope, vote_a.clone())
-        .await
         .expect("peer_b accepts vote_a");
     peer_c
         .process_incoming_vote(&scope, vote_a)
-        .await
         .expect("peer_c accepts vote_a");
 
     let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(voter_b))
-        .await
         .expect("peer_b vote");
     peer_a
         .process_incoming_vote(&scope, vote_b.clone())
-        .await
         .expect("peer_a accepts vote_b");
     peer_c
         .process_incoming_vote(&scope, vote_b)
-        .await
         .expect("peer_c accepts vote_b");
 
     // App-style scheduling: each peer runs its own timeout task.
@@ -267,52 +239,37 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
     let peer_a_task = peer_a.clone();
     let peer_b_task = peer_b.clone();
     let peer_c_task = peer_c.clone();
-    let ha = tokio::spawn(async move {
-        sleep(Duration::from_millis(25)).await;
-        let _ = peer_a_task
-            .handle_consensus_timeout(&scope_a, proposal_id)
-            .await;
+    let ha = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(25));
+        let _ = peer_a_task.handle_consensus_timeout(&scope_a, proposal_id);
     });
-    let hb = tokio::spawn(async move {
-        sleep(Duration::from_millis(25)).await;
-        let _ = peer_b_task
-            .handle_consensus_timeout(&scope_b, proposal_id)
-            .await;
+    let hb = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(25));
+        let _ = peer_b_task.handle_consensus_timeout(&scope_b, proposal_id);
     });
-    let hc = tokio::spawn(async move {
-        sleep(Duration::from_millis(25)).await;
-        let _ = peer_c_task
-            .handle_consensus_timeout(&scope_c, proposal_id)
-            .await;
+    let hc = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(25));
+        let _ = peer_c_task.handle_consensus_timeout(&scope_c, proposal_id);
     });
 
-    ha.await.expect("timeout task A");
-    hb.await.expect("timeout task B");
-    hc.await.expect("timeout task C");
+    ha.join().expect("timeout task A");
+    hb.join().expect("timeout task B");
+    hc.join().expect("timeout task C");
 
     // Converge to "failed" state (no consensus result).
-    let result_a = peer_a
-        .storage()
-        .get_consensus_result(&scope, proposal_id)
-        .await;
+    let result_a = peer_a.storage().get_consensus_result(&scope, proposal_id);
     assert!(
         matches!(result_a, Err(ConsensusError::ConsensusFailed)),
         "peer_a should be in Failed state"
     );
 
-    let result_b = peer_b
-        .storage()
-        .get_consensus_result(&scope, proposal_id)
-        .await;
+    let result_b = peer_b.storage().get_consensus_result(&scope, proposal_id);
     assert!(
         matches!(result_b, Err(ConsensusError::ConsensusFailed)),
         "peer_b should be in Failed state"
     );
 
-    let result_c = peer_c
-        .storage()
-        .get_consensus_result(&scope, proposal_id)
-        .await;
+    let result_c = peer_c.storage().get_consensus_result(&scope, proposal_id);
     assert!(
         matches!(result_c, Err(ConsensusError::ConsensusFailed)),
         "peer_c should be in Failed state"
@@ -321,8 +278,8 @@ async fn test_multi_peer_timeout_task_converges_to_failed() {
 
 /// Four peers, check that the proposal converges to YES by liveness criteria.
 /// Result depends on the liveness criteria as we have 2 YES and 2 NO votes.
-#[tokio::test]
-async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
+#[test]
+fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     let peer_a = make_service();
     let peer_b = make_service();
     let peer_c = make_service();
@@ -345,53 +302,43 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("peer_a proposal");
 
     for peer in [&peer_b, &peer_c, &peer_d] {
         peer.process_incoming_proposal(&scope, proposal.clone())
-            .await
             .expect("peer accepts proposal");
     }
 
     // Cast votes sequentially, gossiping each vote to all peers before the next voter votes,
     // so that received_hash references match on every peer.
     let vote_a = cast_remote_vote(&peer_a, &scope, proposal.proposal_id, true, &wrap(owner_a))
-        .await
         .expect("vote_a");
     for peer in [&peer_b, &peer_c, &peer_d] {
         peer.process_incoming_vote(&scope, vote_a.clone())
-            .await
             .expect("peer accepts vote_a");
     }
 
     let voter_b = PrivateKeySigner::random();
     let vote_b = cast_remote_vote(&peer_b, &scope, proposal.proposal_id, true, &wrap(voter_b))
-        .await
         .expect("vote_b");
     for peer in [&peer_a, &peer_c, &peer_d] {
         peer.process_incoming_vote(&scope, vote_b.clone())
-            .await
             .expect("peer accepts vote_b");
     }
 
     let voter_c = PrivateKeySigner::random();
     let vote_c = cast_remote_vote(&peer_c, &scope, proposal.proposal_id, false, &wrap(voter_c))
-        .await
         .expect("vote_c");
     for peer in [&peer_a, &peer_b, &peer_d] {
         peer.process_incoming_vote(&scope, vote_c.clone())
-            .await
             .expect("peer accepts vote_c");
     }
 
     let voter_d = PrivateKeySigner::random();
     let vote_d = cast_remote_vote(&peer_d, &scope, proposal.proposal_id, false, &wrap(voter_d))
-        .await
         .expect("vote_d");
     for peer in [&peer_a, &peer_b, &peer_c] {
         peer.process_incoming_vote(&scope, vote_d.clone())
-            .await
             .expect("peer accepts vote_d");
     }
 
@@ -406,55 +353,43 @@ async fn test_multi_peer_timeout_task_resolves_tie_by_liveness_criteria_yes() {
     let scope_c = scope.clone();
     let scope_d = scope.clone();
 
-    let ha = tokio::spawn(async move {
-        sleep(Duration::from_millis(10)).await;
-        let _ = peer_a_task
-            .handle_consensus_timeout(&scope_a, proposal_id)
-            .await;
+    let ha = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(10));
+        let _ = peer_a_task.handle_consensus_timeout(&scope_a, proposal_id);
     });
-    let hb = tokio::spawn(async move {
-        sleep(Duration::from_millis(10)).await;
-        let _ = peer_b_task
-            .handle_consensus_timeout(&scope_b, proposal_id)
-            .await;
+    let hb = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(10));
+        let _ = peer_b_task.handle_consensus_timeout(&scope_b, proposal_id);
     });
-    let hc = tokio::spawn(async move {
-        sleep(Duration::from_millis(10)).await;
-        let _ = peer_c_task
-            .handle_consensus_timeout(&scope_c, proposal_id)
-            .await;
+    let hc = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(10));
+        let _ = peer_c_task.handle_consensus_timeout(&scope_c, proposal_id);
     });
-    let hd = tokio::spawn(async move {
-        sleep(Duration::from_millis(10)).await;
-        let _ = peer_d_task
-            .handle_consensus_timeout(&scope_d, proposal_id)
-            .await;
+    let hd = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(10));
+        let _ = peer_d_task.handle_consensus_timeout(&scope_d, proposal_id);
     });
 
-    ha.await.expect("timeout task A");
-    hb.await.expect("timeout task B");
-    hc.await.expect("timeout task C");
-    hd.await.expect("timeout task D");
+    ha.join().expect("timeout task A");
+    hb.join().expect("timeout task B");
+    hc.join().expect("timeout task C");
+    hd.join().expect("timeout task D");
 
     let res_a = peer_a
         .storage()
         .get_consensus_result(&scope, proposal_id)
-        .await
         .expect("peer_a has consensus");
     let res_b = peer_b
         .storage()
         .get_consensus_result(&scope, proposal_id)
-        .await
         .expect("peer_b has consensus");
     let res_c = peer_c
         .storage()
         .get_consensus_result(&scope, proposal_id)
-        .await
         .expect("peer_c has consensus");
     let res_d = peer_d
         .storage()
         .get_consensus_result(&scope, proposal_id)
-        .await
         .expect("peer_d has consensus");
 
     assert!(res_a);

--- a/tests/rfc_compliance_tests.rs
+++ b/tests/rfc_compliance_tests.rs
@@ -1,8 +1,7 @@
-use alloy::signers::{Signer, local::PrivateKeySigner};
+use alloy::signers::{SignerSync, local::PrivateKeySigner};
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 use prost::Message;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::time::sleep;
 
 use hashgraph_like_consensus::{
     error::ConsensusError,
@@ -14,7 +13,7 @@ use hashgraph_like_consensus::{
     utils::{build_vote, compute_vote_hash},
 };
 
-async fn cast_remote_vote(
+fn cast_remote_vote(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -24,13 +23,13 @@ async fn cast_remote_vote(
     hashgraph_like_consensus::protos::consensus::v1::Vote,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
-    let vote = build_vote(&proposal, choice, signer).await?;
-    service.process_incoming_vote(scope, vote.clone()).await?;
+    let proposal = service.storage().get_proposal(scope, proposal_id)?;
+    let vote = build_vote(&proposal, choice, signer)?;
+    service.process_incoming_vote(scope, vote.clone())?;
     Ok(vote)
 }
 
-async fn cast_remote_vote_and_get_proposal(
+fn cast_remote_vote_and_get_proposal(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -40,8 +39,8 @@ async fn cast_remote_vote_and_get_proposal(
     hashgraph_like_consensus::protos::consensus::v1::Proposal,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
-    service.storage().get_proposal(scope, proposal_id).await
+    cast_remote_vote(service, scope, proposal_id, choice, signer)?;
+    service.storage().get_proposal(scope, proposal_id)
 }
 
 fn make_service() -> DefaultConsensusService {
@@ -75,8 +74,8 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
 }
 
 /// Test that proposal initialization has round = 1
-#[tokio::test]
-async fn test_proposal_initialization_round_is_one() {
+#[test]
+fn test_proposal_initialization_round_is_one() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -95,15 +94,14 @@ async fn test_proposal_initialization_round_is_one() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     assert_eq!(proposal.round, 1, "Proposal should start with round = 1");
 }
 
 /// RFC Section 2.5.3: Test that round increments when votes are added (P2P mode)
-#[tokio::test]
-async fn test_round_increments_on_vote_p2p() {
+#[test]
+fn test_round_increments_on_vote_p2p() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -122,7 +120,6 @@ async fn test_round_increments_on_vote_p2p() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::p2p()),
         )
-        .await
         .expect("proposal should be created");
 
     assert_eq!(
@@ -137,7 +134,6 @@ async fn test_round_increments_on_vote_p2p() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should be added");
 
     assert_eq!(
@@ -153,7 +149,6 @@ async fn test_round_increments_on_vote_p2p() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote should be added");
 
     assert_eq!(
@@ -163,8 +158,8 @@ async fn test_round_increments_on_vote_p2p() {
 }
 
 /// RFC Section 2.5.3: Test that gossipsub keeps rounds at 2 for all votes
-#[tokio::test]
-async fn test_gossipsub_rounds_stay_at_two() {
+#[test]
+fn test_gossipsub_rounds_stay_at_two() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -185,7 +180,6 @@ async fn test_gossipsub_rounds_stay_at_two() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     assert_eq!(
@@ -201,7 +195,6 @@ async fn test_gossipsub_rounds_stay_at_two() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should be added");
 
     assert_eq!(
@@ -219,7 +212,6 @@ async fn test_gossipsub_rounds_stay_at_two() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote should be added");
 
     assert_eq!(
@@ -237,7 +229,6 @@ async fn test_gossipsub_rounds_stay_at_two() {
         VOTE_YES,
         &wrap(voter3),
     )
-    .await
     .expect("third vote should be added");
 
     assert_eq!(
@@ -252,8 +243,8 @@ async fn test_gossipsub_rounds_stay_at_two() {
 }
 
 /// Test that gossipsub allows multiple votes in round 2 (not limited to 2 votes)
-#[tokio::test]
-async fn test_gossipsub_allows_multiple_votes_in_round_two() {
+#[test]
+fn test_gossipsub_allows_multiple_votes_in_round_two() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -276,7 +267,6 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     // First vote moves to round 2
@@ -287,7 +277,6 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should be added");
     assert_eq!(last_proposal.round, 2);
     assert_eq!(last_proposal.votes.len(), 1);
@@ -303,7 +292,6 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
             VOTE_YES,
             &wrap(voter),
         )
-        .await
         .unwrap_or_else(|_| panic!("vote {} should be added", i + 2));
         assert_eq!(
             last_proposal.round, 2,
@@ -323,8 +311,8 @@ async fn test_gossipsub_allows_multiple_votes_in_round_two() {
 }
 
 /// Test that P2P mode uses ceil(2n/3) for max rounds when max_rounds = 0
-#[tokio::test]
-async fn test_p2p_dynamic_max_rounds() {
+#[test]
+fn test_p2p_dynamic_max_rounds() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -344,7 +332,6 @@ async fn test_p2p_dynamic_max_rounds() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::p2p()),
         )
-        .await
         .expect("proposal should be created");
 
     // Add 6 votes - should all succeed
@@ -362,7 +349,6 @@ async fn test_p2p_dynamic_max_rounds() {
             VOTE_YES,
             &wrap(voter.clone()),
         )
-        .await
         .unwrap_or_else(|_| panic!("vote {} should be added", i + 1));
         assert_eq!(
             last_proposal.round,
@@ -385,8 +371,7 @@ async fn test_p2p_dynamic_max_rounds() {
     // Verify consensus was reached (this is expected behavior)
     let result = service
         .storage()
-        .get_consensus_result(&scope, last_proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, last_proposal.proposal_id);
     assert!(
         result.is_ok(),
         "Consensus should be reached with 6 YES votes"
@@ -401,8 +386,8 @@ async fn test_p2p_dynamic_max_rounds() {
 }
 
 /// Test P2P ceil(2n/3) calculation for various values of n
-#[tokio::test]
-async fn test_p2p_ceil_calculation_edge_cases() {
+#[test]
+fn test_p2p_ceil_calculation_edge_cases() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
 
@@ -436,7 +421,6 @@ async fn test_p2p_ceil_calculation_edge_cases() {
                 .expect("valid proposal request"),
                 Some(ConsensusConfig::p2p()),
             )
-            .await
             .expect("proposal should be created");
 
         // Add votes up to the limit
@@ -454,7 +438,6 @@ async fn test_p2p_ceil_calculation_edge_cases() {
                 VOTE_YES,
                 &wrap(voter.clone()),
             )
-            .await
             .unwrap_or_else(|_| panic!("vote {} for n={} should succeed", i + 1, n));
         }
 
@@ -469,8 +452,8 @@ async fn test_p2p_ceil_calculation_edge_cases() {
 }
 
 /// Test that gossipsub correctly processes batch votes via process_incoming_proposal
-#[tokio::test]
-async fn test_gossipsub_batch_vote_processing() {
+#[test]
+fn test_gossipsub_batch_vote_processing() {
     let service = make_service();
     let scope = ScopeID::from("batch_gossipsub");
     let proposal_owner = PrivateKeySigner::random();
@@ -490,30 +473,22 @@ async fn test_gossipsub_batch_vote_processing() {
 
     // Add votes to the proposal (simulating votes received from network)
     let voter1 = PrivateKeySigner::random();
-    let vote1 = build_vote(&proposal, VOTE_YES, &wrap(voter1))
-        .await
-        .expect("vote should be created");
+    let vote1 = build_vote(&proposal, VOTE_YES, &wrap(voter1)).expect("vote should be created");
     proposal.votes.push(vote1);
     proposal.round = 2; // Gossipsub: round 2 after first vote
 
     let voter2 = PrivateKeySigner::random();
-    let vote2 = build_vote(&proposal, VOTE_YES, &wrap(voter2))
-        .await
-        .expect("vote should be created");
+    let vote2 = build_vote(&proposal, VOTE_YES, &wrap(voter2)).expect("vote should be created");
     proposal.votes.push(vote2);
     // Round stays at 2 for gossipsub
 
     let voter3 = PrivateKeySigner::random();
-    let vote3 = build_vote(&proposal, VOTE_YES, &wrap(voter3))
-        .await
-        .expect("vote should be created");
+    let vote3 = build_vote(&proposal, VOTE_YES, &wrap(voter3)).expect("vote should be created");
     proposal.votes.push(vote3);
 
     // Process the proposal with multiple votes (batch processing)
     // This should work in gossipsub mode - all votes are in round 2
-    let result = service
-        .process_incoming_proposal(&scope, proposal.clone())
-        .await;
+    let result = service.process_incoming_proposal(&scope, proposal.clone());
     assert!(
         result.is_ok(),
         "Gossipsub: Should accept batch votes in round 2"
@@ -528,7 +503,6 @@ async fn test_gossipsub_batch_vote_processing() {
         VOTE_YES,
         &wrap(voter4),
     )
-    .await
     .expect("additional vote should succeed");
     assert_eq!(
         final_proposal.round, 2,
@@ -542,8 +516,8 @@ async fn test_gossipsub_batch_vote_processing() {
 }
 
 /// Test that P2P correctly processes batch votes via process_incoming_proposal
-#[tokio::test]
-async fn test_p2p_batch_vote_processing() {
+#[test]
+fn test_p2p_batch_vote_processing() {
     let service = make_service();
     let scope = ScopeID::from("batch_p2p");
     let proposal_owner = PrivateKeySigner::random();
@@ -568,17 +542,14 @@ async fn test_p2p_batch_vote_processing() {
     }
 
     for (i, voter) in voters.iter().enumerate() {
-        let vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
-            .await
-            .expect("vote should be created");
+        let vote =
+            build_vote(&proposal, VOTE_YES, &wrap(voter.clone())).expect("vote should be created");
         proposal.votes.push(vote);
         proposal.round = (i + 2) as u32; // P2P: round increments per vote
     }
 
     // Process the proposal with 6 votes (at the limit)
-    let result = service
-        .process_incoming_proposal(&scope, proposal.clone())
-        .await;
+    let result = service.process_incoming_proposal(&scope, proposal.clone());
     assert!(
         result.is_ok(),
         "P2P: Should accept batch votes up to ceil(2n/3)"
@@ -587,8 +558,7 @@ async fn test_p2p_batch_vote_processing() {
     // Verify by checking consensus result (6 YES votes out of 9 reaches consensus)
     let consensus_result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         consensus_result.is_ok(),
         "P2P: Consensus should be reached with 6 YES votes"
@@ -607,16 +577,14 @@ async fn test_p2p_batch_vote_processing() {
         proposal.proposal_id,
         VOTE_YES,
         &wrap(voter7),
-    )
-    .await;
+    );
 
     // The vote might succeed (returns vote) but won't be added because session reached consensus
     // Or it might fail with SessionNotActive
     // Either way, verify the vote count doesn't increase and consensus result stays the same
     let final_consensus = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         final_consensus.is_ok(),
         "P2P: Consensus result should remain YES"
@@ -631,8 +599,8 @@ async fn test_p2p_batch_vote_processing() {
 }
 
 /// Test that consensus can be reached in both modes
-#[tokio::test]
-async fn test_consensus_reachable_in_both_modes() {
+#[test]
+fn test_consensus_reachable_in_both_modes() {
     let service = make_service();
 
     // Test gossipsub mode
@@ -652,7 +620,6 @@ async fn test_consensus_reachable_in_both_modes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     // Add 4 YES votes (all in round 2 for gossipsub)
@@ -669,14 +636,12 @@ async fn test_consensus_reachable_in_both_modes() {
             VOTE_YES,
             &wrap(voter),
         )
-        .await
         .expect("vote should succeed");
     }
 
     let result1 = service
         .storage()
-        .get_consensus_result(&scope1, proposal1.proposal_id)
-        .await;
+        .get_consensus_result(&scope1, proposal1.proposal_id);
     assert!(result1.is_ok(), "Gossipsub: Consensus should be reached");
     assert!(result1.unwrap(), "Gossipsub: Consensus should be reached");
 
@@ -697,7 +662,6 @@ async fn test_consensus_reachable_in_both_modes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::p2p()),
         )
-        .await
         .expect("proposal should be created");
 
     // Add 4 YES votes (rounds increment in P2P)
@@ -714,21 +678,19 @@ async fn test_consensus_reachable_in_both_modes() {
             VOTE_YES,
             &wrap(voter),
         )
-        .await
         .expect("vote should succeed");
     }
 
     let result2 = service
         .storage()
-        .get_consensus_result(&scope2, proposal2.proposal_id)
-        .await;
+        .get_consensus_result(&scope2, proposal2.proposal_id);
     assert!(result2.is_ok(), "P2P: Consensus should be reached");
     assert!(result2.unwrap(), "P2P: Consensus should be reached");
 }
 
 /// RFC Section 4: Test that n ≤ 2 requires unanimous YES votes
-#[tokio::test]
-async fn test_n_le_2_requires_unanimous_yes() {
+#[test]
+fn test_n_le_2_requires_unanimous_yes() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -747,7 +709,6 @@ async fn test_n_le_2_requires_unanimous_yes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -757,14 +718,12 @@ async fn test_n_le_2_requires_unanimous_yes() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("vote should be added");
 
     // Should reach consensus immediately with unanimous YES
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(result.is_ok(), "RFC Section 4: n=1 requires unanimous YES");
     assert!(result.unwrap(), "RFC Section 4: n=1 requires unanimous YES");
 
@@ -785,7 +744,6 @@ async fn test_n_le_2_requires_unanimous_yes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal2 = cast_remote_vote_and_get_proposal(
@@ -795,7 +753,6 @@ async fn test_n_le_2_requires_unanimous_yes() {
         VOTE_YES,
         &wrap(proposal_owner2),
     )
-    .await
     .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
@@ -806,14 +763,12 @@ async fn test_n_le_2_requires_unanimous_yes() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
+    std::thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
     let result = service
         .storage()
-        .get_consensus_result(&scope2, proposal2.proposal_id)
-        .await;
+        .get_consensus_result(&scope2, proposal2.proposal_id);
     assert!(result.is_ok(), "RFC Section 4: n=2 requires unanimous YES");
     assert!(result.unwrap(), "RFC Section 4: n=2 requires unanimous YES");
 
@@ -834,7 +789,6 @@ async fn test_n_le_2_requires_unanimous_yes() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal3 = cast_remote_vote_and_get_proposal(
@@ -844,7 +798,6 @@ async fn test_n_le_2_requires_unanimous_yes() {
         VOTE_YES,
         &wrap(proposal_owner3),
     )
-    .await
     .expect("first vote");
 
     let voter3 = PrivateKeySigner::random();
@@ -855,14 +808,12 @@ async fn test_n_le_2_requires_unanimous_yes() {
         VOTE_NO,
         &wrap(voter3),
     )
-    .await
     .expect("second vote");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
+    std::thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
     let result = service
         .storage()
-        .get_consensus_result(&scope3, proposal3.proposal_id)
-        .await;
+        .get_consensus_result(&scope3, proposal3.proposal_id);
     assert!(
         result.is_ok(),
         "RFC Section 4: n=2 with non-unanimous should be NO"
@@ -874,8 +825,8 @@ async fn test_n_le_2_requires_unanimous_yes() {
 }
 
 /// RFC Section 4: Test that n > 2 requires more than n/2 YES votes among 2n/3 distinct peers
-#[tokio::test]
-async fn test_n_gt_2_consensus_requirements() {
+#[test]
+fn test_n_gt_2_consensus_requirements() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -894,7 +845,6 @@ async fn test_n_gt_2_consensus_requirements() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -904,14 +854,12 @@ async fn test_n_gt_2_consensus_requirements() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote");
 
     // Only 1 YES vote, not enough (need 2)
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         result.is_err(),
         "Should not reach consensus with only 1 vote"
@@ -929,14 +877,12 @@ async fn test_n_gt_2_consensus_requirements() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
+    std::thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         result.is_ok(),
         "RFC Section 4: Should reach YES consensus with 2 YES votes out of 3"
@@ -948,8 +894,8 @@ async fn test_n_gt_2_consensus_requirements() {
 }
 
 /// RFC Section 2.5.4: Test that expired proposals are rejected
-#[tokio::test]
-async fn test_expired_proposal_rejected() {
+#[test]
+fn test_expired_proposal_rejected() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -968,10 +914,9 @@ async fn test_expired_proposal_rejected() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
-    sleep(Duration::from_secs(EXPIRATION_WAIT_TIME_2_SECOND)).await;
+    std::thread::sleep(Duration::from_secs(EXPIRATION_WAIT_TIME_2_SECOND));
     let voter = PrivateKeySigner::random();
     let err = cast_remote_vote(
         &service,
@@ -980,7 +925,6 @@ async fn test_expired_proposal_rejected() {
         VOTE_YES,
         &wrap(voter),
     )
-    .await
     .expect_err("Should reject vote on expired proposal");
 
     // process_incoming_vote rejects via validate_vote (VoteExpired) when the
@@ -997,8 +941,8 @@ async fn test_expired_proposal_rejected() {
 }
 
 /// RFC Section 3.4: Test timestamp replay attack protection
-#[tokio::test]
-async fn test_timestamp_replay_attack_protection() {
+#[test]
+fn test_timestamp_replay_attack_protection() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -1017,7 +961,6 @@ async fn test_timestamp_replay_attack_protection() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1027,7 +970,6 @@ async fn test_timestamp_replay_attack_protection() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote");
 
     // Create a vote with old timestamp (more than 1 hour ago)
@@ -1038,9 +980,7 @@ async fn test_timestamp_replay_attack_protection() {
         .saturating_sub(EXPIRATION * 2); // More than expiration time
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone()))
-        .await
-        .expect("create vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter.clone())).expect("create vote");
 
     // Manually set old timestamp
     vote.timestamp = old_timestamp;
@@ -1048,15 +988,13 @@ async fn test_timestamp_replay_attack_protection() {
     vote.signature.clear();
     let vote_bytes = vote.encode_to_vec();
     vote.signature = voter
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("sign vote")
         .as_bytes()
         .to_vec();
 
     let err = service
         .process_incoming_vote(&scope, vote)
-        .await
         .expect_err("Should reject vote with old timestamp");
 
     assert!(
@@ -1066,8 +1004,8 @@ async fn test_timestamp_replay_attack_protection() {
 }
 
 /// RFC Section 4: Test equality of votes handling
-#[tokio::test]
-async fn test_equality_of_votes_handling() {
+#[test]
+fn test_equality_of_votes_handling() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -1089,7 +1027,6 @@ async fn test_equality_of_votes_handling() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -1099,7 +1036,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("first vote");
 
     let voter2 = PrivateKeySigner::random();
@@ -1110,7 +1046,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_YES,
         &wrap(voter2),
     )
-    .await
     .expect("second vote");
 
     let voter3 = PrivateKeySigner::random();
@@ -1121,7 +1056,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_NO,
         &wrap(voter3),
     )
-    .await
     .expect("third vote");
 
     let voter4 = PrivateKeySigner::random();
@@ -1132,16 +1066,14 @@ async fn test_equality_of_votes_handling() {
         VOTE_NO,
         &wrap(voter4),
     )
-    .await
     .expect("fourth vote");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
+    std::thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
     // We have 4 votes: 2 YES, 2 NO (equality)
     // With liveness_criteria_yes = true, should resolve to YES
     let result = service
         .storage()
-        .get_consensus_result(&scope, proposal.proposal_id)
-        .await;
+        .get_consensus_result(&scope, proposal.proposal_id);
     assert!(
         result.is_ok(),
         "RFC Section 4: Equality with liveness_criteria_yes=true should be YES"
@@ -1169,7 +1101,6 @@ async fn test_equality_of_votes_handling() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal should be created");
 
     let proposal2 = cast_remote_vote_and_get_proposal(
@@ -1179,7 +1110,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_YES,
         &wrap(proposal_owner2),
     )
-    .await
     .expect("first vote");
 
     let voter2_2 = PrivateKeySigner::random();
@@ -1190,7 +1120,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_YES,
         &wrap(voter2_2),
     )
-    .await
     .expect("second vote");
 
     let voter3_2 = PrivateKeySigner::random();
@@ -1201,7 +1130,6 @@ async fn test_equality_of_votes_handling() {
         VOTE_NO,
         &wrap(voter3_2),
     )
-    .await
     .expect("third vote");
 
     let voter4_2 = PrivateKeySigner::random();
@@ -1212,15 +1140,13 @@ async fn test_equality_of_votes_handling() {
         VOTE_NO,
         &wrap(voter4_2),
     )
-    .await
     .expect("fourth vote");
 
-    sleep(Duration::from_millis(EXPIRATION_WAIT_TIME)).await;
+    std::thread::sleep(Duration::from_millis(EXPIRATION_WAIT_TIME));
     // Equality with liveness_criteria_yes = false should resolve to NO
     let result = service
         .storage()
-        .get_consensus_result(&scope2, proposal2.proposal_id)
-        .await;
+        .get_consensus_result(&scope2, proposal2.proposal_id);
     assert!(
         result.is_ok(),
         "RFC Section 4: Equality with liveness_criteria_yes=false should be NO"

--- a/tests/scope_config_tests.rs
+++ b/tests/scope_config_tests.rs
@@ -17,26 +17,24 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_DOUBLE_TIMEOUT: Duration = Duration::from_secs(120);
 const DEFAULT_SHORT_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[tokio::test]
-async fn test_scope_config_creation() {
+#[test]
+fn test_scope_config_creation() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE_NAME);
 
     // Initialize scope with P2P network and custom threshold
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_type(NetworkType::P2P)
         .with_threshold(0.75)
         .with_timeout(DEFAULT_DOUBLE_TIMEOUT)
         .with_liveness_criteria(true)
         .initialize()
-        .await
         .unwrap();
 
     // Verify the configuration was saved
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     assert_eq!(config.network_type, NetworkType::P2P);
     assert_eq!(config.default_consensus_threshold, 0.75);
@@ -44,72 +42,64 @@ async fn test_scope_config_creation() {
     assert!(config.default_liveness_criteria_yes);
 }
 
-#[tokio::test]
-async fn test_scope_config_update() {
+#[test]
+fn test_scope_config_update() {
     let service = make_service();
     let scope = ScopeID::from("update_test_scope");
 
     // Initialize with default config
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_type(NetworkType::Gossipsub)
         .with_threshold(2.0 / 3.0)
         .with_timeout(DEFAULT_TIMEOUT)
         .initialize()
-        .await
         .unwrap();
 
     // Update only threshold
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_threshold(0.8)
         .update()
-        .await
         .unwrap();
 
     // Verify threshold was updated, but other fields remain unchanged
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     assert_eq!(config.default_consensus_threshold, 0.8);
     assert_eq!(config.network_type, NetworkType::Gossipsub); // Should remain unchanged
     assert_eq!(config.default_timeout, DEFAULT_TIMEOUT); // Should remain unchanged
 }
 
-#[tokio::test]
-async fn test_scope_config_update_multiple_fields() {
+#[test]
+fn test_scope_config_update_multiple_fields() {
     let service = make_service();
     let scope = ScopeID::from("multi_update_scope");
 
     // Initialize with initial config
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_type(NetworkType::P2P)
         .with_threshold(0.6)
         .with_timeout(DEFAULT_SHORT_TIMEOUT)
         .initialize()
-        .await
         .unwrap();
 
     // Update multiple fields at once
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_threshold(0.9)
         .with_timeout(DEFAULT_DOUBLE_TIMEOUT)
         .with_liveness_criteria(false)
         .update()
-        .await
         .unwrap();
 
     // Verify all fields were updated
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     assert_eq!(config.default_consensus_threshold, 0.9);
     assert_eq!(config.default_timeout, DEFAULT_DOUBLE_TIMEOUT);
@@ -117,22 +107,20 @@ async fn test_scope_config_update_multiple_fields() {
     assert_eq!(config.network_type, NetworkType::P2P); // Should remain unchanged
 }
 
-#[tokio::test]
-async fn test_scope_config_presets() {
+#[test]
+fn test_scope_config_presets() {
     let service = make_service();
     let scope = ScopeID::from("preset_test_scope");
 
     // Test P2P preset
     service
         .scope(&scope)
-        .await
         .unwrap()
         .p2p_preset()
         .initialize()
-        .await
         .unwrap();
 
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     assert_eq!(config.network_type, NetworkType::P2P);
     assert_eq!(config.default_consensus_threshold, 2.0 / 3.0);
@@ -141,31 +129,27 @@ async fn test_scope_config_presets() {
     // Test Gossipsub preset
     service
         .scope(&scope)
-        .await
         .unwrap()
         .gossipsub_preset()
         .update()
-        .await
         .unwrap();
 
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     assert_eq!(config.network_type, NetworkType::Gossipsub);
 }
 
-#[tokio::test]
-async fn test_scope_config_validation() {
+#[test]
+fn test_scope_config_validation() {
     let service = make_service();
     let scope = ScopeID::from("validation_test_scope");
 
     // Test invalid threshold (too high)
     let result = service
         .scope(&scope)
-        .await
         .unwrap()
         .with_threshold(1.5) // Invalid: > 1.0
-        .initialize()
-        .await;
+        .initialize();
 
     assert!(result.is_err());
     assert!(matches!(
@@ -176,22 +160,18 @@ async fn test_scope_config_validation() {
     // Test invalid threshold (negative)
     let result = service
         .scope(&scope)
-        .await
         .unwrap()
         .with_threshold(-0.1) // Invalid: < 0.0
-        .initialize()
-        .await;
+        .initialize();
 
     assert!(result.is_err());
 
     // Test invalid timeout (zero)
     let result = service
         .scope(&scope)
-        .await
         .unwrap()
         .with_timeout(Duration::from_secs(0)) // Invalid: must be > 0
-        .initialize()
-        .await;
+        .initialize();
 
     assert!(result.is_err());
     assert!(matches!(
@@ -200,13 +180,13 @@ async fn test_scope_config_validation() {
     ));
 }
 
-#[tokio::test]
-async fn test_scope_config_new_scope_uses_defaults() {
+#[test]
+fn test_scope_config_new_scope_uses_defaults() {
     let service = make_service();
     let scope = ScopeID::from("new_scope_defaults");
 
     // Get config for non-existent scope - should return defaults
-    let config = service.scope(&scope).await.unwrap().get_config();
+    let config = service.scope(&scope).unwrap().get_config();
 
     // Should have default values
     assert_eq!(config.network_type, NetworkType::Gossipsub);
@@ -215,8 +195,8 @@ async fn test_scope_config_new_scope_uses_defaults() {
     assert!(config.default_liveness_criteria_yes);
 }
 
-#[tokio::test]
-async fn test_max_rounds_override_zero_validation() {
+#[test]
+fn test_max_rounds_override_zero_validation() {
     let service = make_service();
     let scope_p2p = ScopeID::from("p2p_zero_rounds");
     let scope_gossipsub = ScopeID::from("gossipsub_zero_rounds");
@@ -225,31 +205,27 @@ async fn test_max_rounds_override_zero_validation() {
     // (0 triggers dynamic calculation based on consensus threshold)
     let result = service
         .scope(&scope_p2p)
-        .await
         .unwrap()
         .with_network_type(NetworkType::P2P)
         .with_max_rounds(Some(0))
-        .initialize()
-        .await;
+        .initialize();
 
     assert!(
         result.is_ok(),
         "max_rounds_override = Some(0) should be allowed for P2P networks"
     );
 
-    let config = service.scope(&scope_p2p).await.unwrap().get_config();
+    let config = service.scope(&scope_p2p).unwrap().get_config();
     assert_eq!(config.max_rounds_override, Some(0));
     assert_eq!(config.network_type, NetworkType::P2P);
 
     // Test that max_rounds_override = Some(0) is rejected for Gossipsub networks
     let result = service
         .scope(&scope_gossipsub)
-        .await
         .unwrap()
         .with_network_type(NetworkType::Gossipsub)
         .with_max_rounds(Some(0))
-        .initialize()
-        .await;
+        .initialize();
 
     assert!(
         result.is_err(),
@@ -261,8 +237,8 @@ async fn test_max_rounds_override_zero_validation() {
     ));
 }
 
-#[tokio::test]
-async fn create_proposal_with_config_preserves_override_timeout() {
+#[test]
+fn create_proposal_with_config_preserves_override_timeout() {
     let service = make_service();
     let scope = ScopeID::from("test_scope");
 
@@ -282,95 +258,82 @@ async fn create_proposal_with_config_preserves_override_timeout() {
 
     let proposal = service
         .create_proposal_with_config(&scope, request, Some(override_config))
-        .await
         .unwrap();
 
     let config = service
         .storage()
         .get_proposal_config(&scope, proposal.proposal_id)
-        .await
         .unwrap();
 
     assert_eq!(config.consensus_timeout(), Duration::from_secs(120));
 }
 
-#[tokio::test]
-async fn test_scope_config_convenience_profiles_and_network_defaults() {
+#[test]
+fn test_scope_config_convenience_profiles_and_network_defaults() {
     let service = make_service();
     let scope = ScopeID::from("convenience_profiles_scope");
 
     // Ensure strict profile is applied and persists through initialize.
     service
         .scope(&scope)
-        .await
         .unwrap()
         .strict_consensus()
         .initialize()
-        .await
         .unwrap();
 
-    let strict = service.scope(&scope).await.unwrap().get_config();
+    let strict = service.scope(&scope).unwrap().get_config();
     assert_eq!(strict.default_consensus_threshold, 0.9);
 
     // Ensure fast profile updates threshold+timeout.
     service
         .scope(&scope)
-        .await
         .unwrap()
         .fast_consensus()
         .update()
-        .await
         .unwrap();
 
-    let fast = service.scope(&scope).await.unwrap().get_config();
+    let fast = service.scope(&scope).unwrap().get_config();
     assert_eq!(fast.default_consensus_threshold, 0.6);
     assert_eq!(fast.default_timeout, Duration::from_secs(30));
 
     // Exercise both branches of with_network_defaults.
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_defaults(NetworkType::P2P)
         .update()
-        .await
         .unwrap();
 
-    let p2p = service.scope(&scope).await.unwrap().get_config();
+    let p2p = service.scope(&scope).unwrap().get_config();
     assert_eq!(p2p.network_type, NetworkType::P2P);
 
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_defaults(NetworkType::Gossipsub)
         .update()
-        .await
         .unwrap();
 
-    let gossipsub = service.scope(&scope).await.unwrap().get_config();
+    let gossipsub = service.scope(&scope).unwrap().get_config();
     assert_eq!(gossipsub.network_type, NetworkType::Gossipsub);
 }
 
-#[tokio::test]
-async fn test_scope_config_update_replaces_all_fields() {
+#[test]
+fn test_scope_config_update_replaces_all_fields() {
     let service = make_service();
     let scope = ScopeID::from("replace_all_fields_scope");
 
     // Initialize with P2P defaults
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_type(NetworkType::P2P)
         .initialize()
-        .await
         .unwrap();
 
     // Update all fields at once
     service
         .scope(&scope)
-        .await
         .unwrap()
         .with_network_type(NetworkType::Gossipsub)
         .with_threshold(0.8)
@@ -378,10 +341,9 @@ async fn test_scope_config_update_replaces_all_fields() {
         .with_liveness_criteria(false)
         .with_max_rounds(Some(7))
         .update()
-        .await
         .unwrap();
 
-    let built = service.scope(&scope).await.unwrap().get_config();
+    let built = service.scope(&scope).unwrap().get_config();
     assert_eq!(built.network_type, NetworkType::Gossipsub);
     assert_eq!(built.default_consensus_threshold, 0.8);
     assert_eq!(built.default_timeout, Duration::from_secs(90));

--- a/tests/storage_stream_tests.rs
+++ b/tests/storage_stream_tests.rs
@@ -1,4 +1,3 @@
-use futures::StreamExt;
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
 use hashgraph_like_consensus::{
@@ -35,8 +34,8 @@ fn make_session(name: &str) -> ConsensusSession {
     session
 }
 
-#[tokio::test]
-async fn test_stream_scope_sessions_yields_all_sessions_in_scope() {
+#[test]
+fn test_stream_scope_sessions_yields_all_sessions_in_scope() {
     let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
     let scope = ScopeID::from(SCOPE);
 
@@ -45,18 +44,13 @@ async fn test_stream_scope_sessions_yields_all_sessions_in_scope() {
 
     storage
         .save_session(&scope, session1.clone())
-        .await
         .expect("save session1");
     storage
         .save_session(&scope, session2.clone())
-        .await
         .expect("save session2");
 
     let mut got_ids: Vec<u32> = storage
         .stream_scope_sessions(&scope)
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
         .map(|r| r.expect("stream item").proposal.proposal_id)
         .collect();
     got_ids.sort_unstable();
@@ -67,29 +61,25 @@ async fn test_stream_scope_sessions_yields_all_sessions_in_scope() {
     assert_eq!(got_ids, expected_ids);
 }
 
-#[tokio::test]
-async fn test_stream_scope_sessions_missing_scope_is_empty() {
+#[test]
+fn test_stream_scope_sessions_missing_scope_is_empty() {
     let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
     let missing_scope = ScopeID::from(MISSING_SCOPE);
 
-    let items: Vec<_> = storage
-        .stream_scope_sessions(&missing_scope)
-        .collect::<Vec<_>>()
-        .await;
+    let items: Vec<_> = storage.stream_scope_sessions(&missing_scope).collect();
     assert!(items.is_empty());
 }
 
-#[tokio::test]
-async fn test_remove_list_scopes_and_replace_scope_sessions() {
+#[test]
+fn test_remove_list_scopes_and_replace_scope_sessions() {
     let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
     let scope = ScopeID::from("remove_replace_scope");
 
     // Empty storage should return None for scopes and scope sessions.
-    assert!(storage.list_scopes().await.expect("list scopes").is_none());
+    assert!(storage.list_scopes().expect("list scopes").is_none());
     assert!(
         storage
             .list_scope_sessions(&scope)
-            .await
             .expect("list scope sessions")
             .is_none()
     );
@@ -99,12 +89,10 @@ async fn test_remove_list_scopes_and_replace_scope_sessions() {
     let proposal_id = session.proposal.proposal_id;
     storage
         .save_session(&scope, session.clone())
-        .await
         .expect("save session");
 
     let scopes = storage
         .list_scopes()
-        .await
         .expect("list scopes")
         .expect("should have one scope");
     assert_eq!(scopes, vec![scope.clone()]);
@@ -112,13 +100,11 @@ async fn test_remove_list_scopes_and_replace_scope_sessions() {
     // Remove existing and then missing session.
     let removed = storage
         .remove_session(&scope, proposal_id)
-        .await
         .expect("remove existing");
     assert!(removed.is_some());
 
     let removed_missing = storage
         .remove_session(&scope, proposal_id)
-        .await
         .expect("remove missing");
     assert!(removed_missing.is_none());
 
@@ -127,28 +113,23 @@ async fn test_remove_list_scopes_and_replace_scope_sessions() {
     let replacement2 = make_session("replacement2");
     storage
         .replace_scope_sessions(&scope, vec![replacement1.clone(), replacement2.clone()])
-        .await
         .expect("replace scope sessions");
 
     let listed = storage
         .list_scope_sessions(&scope)
-        .await
         .expect("list after replace")
         .expect("scope must exist after replace");
     assert_eq!(listed.len(), 2);
 }
 
-#[tokio::test]
-async fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths() {
+#[test]
+fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths() {
     let storage: InMemoryConsensusStorage<ScopeID> = InMemoryConsensusStorage::new();
     let scope = ScopeID::from("update_scope_sessions_scope");
 
     let session = make_session("updatable");
     let proposal_id = session.proposal.proposal_id;
-    storage
-        .save_session(&scope, session)
-        .await
-        .expect("save session");
+    storage.save_session(&scope, session).expect("save session");
 
     // update_session success path.
     let updated_name = storage
@@ -156,14 +137,12 @@ async fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths()
             session.proposal.name = "mutated".to_string();
             Ok(session.proposal.name.clone())
         })
-        .await
         .expect("update session");
     assert_eq!(updated_name, "mutated");
 
     // update_session missing path.
     let err = storage
         .update_session(&scope, u32::MAX, |_session| Ok(()))
-        .await
         .expect_err("missing session should fail");
     assert!(matches!(
         err,
@@ -175,7 +154,6 @@ async fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths()
         .update_scope_sessions(&scope, |_sessions| {
             Err(hashgraph_like_consensus::error::ConsensusError::ConsensusFailed)
         })
-        .await
         .expect_err("mutator error should bubble up");
     assert!(matches!(
         err,
@@ -188,20 +166,18 @@ async fn test_update_session_and_update_scope_sessions_error_and_cleanup_paths()
             sessions.clear();
             Ok(())
         })
-        .await
         .expect("cleanup update");
 
     assert!(
         storage
             .list_scope_sessions(&scope)
-            .await
             .expect("list after cleanup")
             .is_none()
     );
 }
 
-#[tokio::test]
-async fn test_scope_config_storage_validation_and_updates() {
+#[test]
+fn test_scope_config_storage_validation_and_updates() {
     use hashgraph_like_consensus::{
         error::ConsensusError,
         scope_config::{NetworkType, ScopeConfig},
@@ -213,7 +189,6 @@ async fn test_scope_config_storage_validation_and_updates() {
     assert!(
         storage
             .get_scope_config(&scope)
-            .await
             .expect("get config")
             .is_none()
     );
@@ -228,7 +203,6 @@ async fn test_scope_config_storage_validation_and_updates() {
     };
     let err = storage
         .set_scope_config(&scope, invalid)
-        .await
         .expect_err("invalid config should fail");
     assert!(matches!(err, ConsensusError::InvalidMaxRounds));
 
@@ -239,12 +213,10 @@ async fn test_scope_config_storage_validation_and_updates() {
             config.max_rounds_override = Some(0);
             Ok(())
         })
-        .await
         .expect("update scope config");
 
     let cfg = storage
         .get_scope_config(&scope)
-        .await
         .expect("get updated config")
         .expect("config should exist");
     assert_eq!(cfg.network_type, NetworkType::P2P);
@@ -253,7 +225,6 @@ async fn test_scope_config_storage_validation_and_updates() {
     // updater error path.
     let err = storage
         .update_scope_config(&scope, |_config| Err(ConsensusError::ConsensusFailed))
-        .await
         .expect_err("updater error should fail");
     assert!(matches!(err, ConsensusError::ConsensusFailed));
 
@@ -264,7 +235,6 @@ async fn test_scope_config_storage_validation_and_updates() {
             config.max_rounds_override = Some(0);
             Ok(())
         })
-        .await
         .expect_err("invalid updated config should fail validation");
     assert!(matches!(err, ConsensusError::InvalidMaxRounds));
 }

--- a/tests/vote_tests.rs
+++ b/tests/vote_tests.rs
@@ -23,8 +23,8 @@ const EXPECTED_VOTERS_COUNT: u32 = 3;
 const VOTE_YES: bool = true;
 const VOTE_NO: bool = false;
 
-#[tokio::test]
-async fn test_received_hash_for_new_voter() {
+#[test]
+fn test_received_hash_for_new_voter() {
     let proposal_owner = wrap(PrivateKeySigner::random());
     let service = DefaultConsensusService::new(proposal_owner.clone());
     let scope = ScopeID::from(SCOPE);
@@ -43,18 +43,14 @@ async fn test_received_hash_for_new_voter() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let proposal = service
         .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES)
-        .await
         .expect("proposal_owner vote");
 
     let other_voter = wrap(PrivateKeySigner::random());
-    let vote = build_vote(&proposal, VOTE_YES, &other_voter)
-        .await
-        .expect("second vote");
+    let vote = build_vote(&proposal, VOTE_YES, &other_voter).expect("second vote");
 
     assert!(
         vote.parent_hash.is_empty(),
@@ -71,8 +67,8 @@ async fn test_received_hash_for_new_voter() {
         .expect("proposal with second voter should validate");
 }
 
-#[tokio::test]
-async fn test_parent_hash_for_same_voter() {
+#[test]
+fn test_parent_hash_for_same_voter() {
     let proposal_owner = wrap(PrivateKeySigner::random());
     let service = DefaultConsensusService::new(proposal_owner.clone());
     let scope = ScopeID::from(SCOPE);
@@ -91,18 +87,14 @@ async fn test_parent_hash_for_same_voter() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let proposal = service
         .cast_vote_and_get_proposal(&scope, proposal.proposal_id, VOTE_YES)
-        .await
         .expect("proposal_owner vote");
 
     // Create a second vote from the same voter to exercise parent_hash logic.
-    let second_vote = build_vote(&proposal, VOTE_NO, &proposal_owner)
-        .await
-        .expect("second vote");
+    let second_vote = build_vote(&proposal, VOTE_NO, &proposal_owner).expect("second vote");
 
     assert!(
         second_vote.received_hash == proposal.votes[0].vote_hash,

--- a/tests/vote_validation_tests.rs
+++ b/tests/vote_validation_tests.rs
@@ -1,4 +1,4 @@
-use alloy::signers::{Signer, local::PrivateKeySigner};
+use alloy::signers::{SignerSync, local::PrivateKeySigner};
 use hashgraph_like_consensus::signing::EthereumConsensusSigner;
 
 use prost::Message;
@@ -13,7 +13,7 @@ use hashgraph_like_consensus::{
     utils::{build_vote, compute_vote_hash, validate_proposal},
 };
 
-async fn cast_remote_vote(
+fn cast_remote_vote(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -23,13 +23,13 @@ async fn cast_remote_vote(
     hashgraph_like_consensus::protos::consensus::v1::Vote,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    let proposal = service.storage().get_proposal(scope, proposal_id).await?;
-    let vote = build_vote(&proposal, choice, signer).await?;
-    service.process_incoming_vote(scope, vote.clone()).await?;
+    let proposal = service.storage().get_proposal(scope, proposal_id)?;
+    let vote = build_vote(&proposal, choice, signer)?;
+    service.process_incoming_vote(scope, vote.clone())?;
     Ok(vote)
 }
 
-async fn cast_remote_vote_and_get_proposal(
+fn cast_remote_vote_and_get_proposal(
     service: &DefaultConsensusService,
     scope: &ScopeID,
     proposal_id: u32,
@@ -39,8 +39,8 @@ async fn cast_remote_vote_and_get_proposal(
     hashgraph_like_consensus::protos::consensus::v1::Proposal,
     hashgraph_like_consensus::error::ConsensusError,
 > {
-    cast_remote_vote(service, scope, proposal_id, choice, signer).await?;
-    service.storage().get_proposal(scope, proposal_id).await
+    cast_remote_vote(service, scope, proposal_id, choice, signer)?;
+    service.storage().get_proposal(scope, proposal_id)
 }
 
 fn make_service() -> DefaultConsensusService {
@@ -67,7 +67,7 @@ fn owner_bytes(signer: &PrivateKeySigner) -> Vec<u8> {
     signer.address().as_slice().to_vec()
 }
 
-async fn resign_vote(
+fn resign_vote(
     vote: &mut hashgraph_like_consensus::protos::consensus::v1::Vote,
     signer: &PrivateKeySigner,
 ) {
@@ -75,15 +75,14 @@ async fn resign_vote(
     vote.signature.clear();
     let vote_bytes = vote.encode_to_vec();
     vote.signature = signer
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("vote should be resignable")
         .as_bytes()
         .to_vec();
 }
 
-#[tokio::test]
-async fn test_vote_created_with_helper_is_valid() {
+#[test]
+fn test_vote_created_with_helper_is_valid() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -102,7 +101,6 @@ async fn test_vote_created_with_helper_is_valid() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -112,22 +110,18 @@ async fn test_vote_created_with_helper_is_valid() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
-        .await
-        .expect("vote should be created");
+    let vote = build_vote(&proposal, VOTE_YES, &wrap(voter)).expect("vote should be created");
 
     service
         .process_incoming_vote(&scope, vote)
-        .await
         .expect("vote should validate");
 }
 
-#[tokio::test]
-async fn test_invalid_signature_is_rejected() {
+#[test]
+fn test_invalid_signature_is_rejected() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -146,7 +140,6 @@ async fn test_invalid_signature_is_rejected() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -156,19 +149,15 @@ async fn test_invalid_signature_is_rejected() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("proposal_owner vote");
 
     let voter = PrivateKeySigner::random();
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter))
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(voter)).expect("vote");
 
     let wrong_signer = PrivateKeySigner::random();
     let vote_bytes = vote.encode_to_vec();
     let wrong_sig = wrong_signer
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("should sign with wrong key");
     vote.signature = wrong_sig.as_bytes().to_vec();
 
@@ -183,8 +172,8 @@ async fn test_invalid_signature_is_rejected() {
     );
 }
 
-#[tokio::test]
-async fn test_vote_chain_validation_rejects_bad_received_hash() {
+#[test]
+fn test_vote_chain_validation_rejects_bad_received_hash() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -203,7 +192,6 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let proposal = cast_remote_vote_and_get_proposal(
@@ -213,26 +201,20 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
         VOTE_YES,
         &wrap(proposal_owner),
     )
-    .await
     .expect("proposal_owner vote");
 
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one))
-        .await
-        .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone()))
-        .await
-        .expect("vote two");
+    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one)).expect("vote one");
+    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone())).expect("vote two");
 
     vote_two.received_hash = vec![0; 32];
     vote_two.vote_hash = compute_vote_hash(&vote_two);
     vote_two.signature.clear();
     let vote_bytes = vote_two.encode_to_vec();
     vote_two.signature = voter_two
-        .sign_message(&vote_bytes)
-        .await
+        .sign_message_sync(&vote_bytes)
         .expect("sign corrupted vote")
         .as_bytes()
         .to_vec();
@@ -249,8 +231,8 @@ async fn test_vote_chain_validation_rejects_bad_received_hash() {
     );
 }
 
-#[tokio::test]
-async fn test_validate_proposal_rejects_empty_vote_owner() {
+#[test]
+fn test_validate_proposal_rejects_empty_vote_owner() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -269,12 +251,9 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner)).expect("vote");
     vote.vote_owner.clear();
 
     let mut invalid = proposal;
@@ -285,8 +264,8 @@ async fn test_validate_proposal_rejects_empty_vote_owner() {
     assert!(matches!(err, ConsensusError::EmptyVoteOwner));
 }
 
-#[tokio::test]
-async fn test_validate_proposal_rejects_empty_vote_hash() {
+#[test]
+fn test_validate_proposal_rejects_empty_vote_hash() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -305,12 +284,9 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner)).expect("vote");
     vote.vote_hash.clear();
 
     let mut invalid = proposal;
@@ -321,8 +297,8 @@ async fn test_validate_proposal_rejects_empty_vote_hash() {
     assert!(matches!(err, ConsensusError::EmptyVoteHash));
 }
 
-#[tokio::test]
-async fn test_validate_proposal_rejects_empty_signature() {
+#[test]
+fn test_validate_proposal_rejects_empty_signature() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -341,12 +317,9 @@ async fn test_validate_proposal_rejects_empty_signature() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner)).expect("vote");
     vote.signature.clear();
 
     let mut invalid = proposal;
@@ -357,8 +330,8 @@ async fn test_validate_proposal_rejects_empty_signature() {
     assert!(matches!(err, ConsensusError::EmptySignature));
 }
 
-#[tokio::test]
-async fn test_validate_proposal_rejects_mismatched_signature_length() {
+#[test]
+fn test_validate_proposal_rejects_mismatched_signature_length() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -377,12 +350,9 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
-    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner))
-        .await
-        .expect("vote");
+    let mut vote = build_vote(&proposal, VOTE_YES, &wrap(proposal_owner)).expect("vote");
     vote.signature = vec![7; 64];
 
     let mut invalid = proposal;
@@ -395,8 +365,8 @@ async fn test_validate_proposal_rejects_mismatched_signature_length() {
     assert!(matches!(err, ConsensusError::SignatureScheme(_)));
 }
 
-#[tokio::test]
-async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
+#[test]
+fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
     let service = make_service();
     let scope = ScopeID::from(SCOPE);
     let proposal_owner = PrivateKeySigner::random();
@@ -415,22 +385,17 @@ async fn test_vote_chain_validation_rejects_bad_parent_hash_owner_mismatch() {
             .expect("valid proposal request"),
             Some(ConsensusConfig::gossipsub()),
         )
-        .await
         .expect("proposal");
 
     let voter_one = PrivateKeySigner::random();
     let voter_two = PrivateKeySigner::random();
 
-    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one))
-        .await
-        .expect("vote one");
-    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone()))
-        .await
-        .expect("vote two");
+    let vote_one = build_vote(&proposal, VOTE_YES, &wrap(voter_one)).expect("vote one");
+    let mut vote_two = build_vote(&proposal, VOTE_NO, &wrap(voter_two.clone())).expect("vote two");
 
     // parent_hash points to another owner's vote, which should fail RFC parent-chain checks.
     vote_two.parent_hash = vote_one.vote_hash.clone();
-    resign_vote(&mut vote_two, &voter_two).await;
+    resign_vote(&mut vote_two, &voter_two);
 
     let mut invalid = proposal;
     invalid.votes.push(vote_one);


### PR DESCRIPTION
## Summary

Converts the crate to a **fully synchronous** API — no `async`/`.await`/futures anywhere, and `tokio`/`futures`/`async-stream` are dropped as dependencies. Bumps the version to **0.5.0** (breaking).

### What changed
- **Service / storage / events / signing** methods are now plain sync `fn`s. Remove `.await` from all call sites:
  ```rust
  // before
  let vote = service.cast_vote(&scope, id, choice).await?;
  // after
  let vote = service.cast_vote(&scope, id, choice)?;
  ```
- **Signing**: `EthereumConsensusSigner` signs via alloy's `SignerSync::sign_message_sync` (alloy stays; no crate swap). `ConsensusSignatureScheme::sign` is now sync.
- **Storage**: `InMemoryConsensusStorage` uses `parking_lot::RwLock`; `stream_scope_sessions` returns `impl Iterator` instead of a `futures::Stream`.
- **Events**: `BroadcastEventBus` fans out over `std::sync::mpsc`. `subscribe()` returns a `std::sync::mpsc::Receiver`; use `recv()` / `try_recv()` / `recv_timeout()` (was `recv().await`). Slow subscribers miss events rather than blocking the publisher.
- **Tests**: converted to sync; `concurrency_tests` use `std::thread` + `std::sync::Barrier`.

### New `ethereum` feature (default-on)
Gates the alloy-backed `EthereumConsensusSigner` and the `DefaultConsensusService` alias. Consumers bringing their own `ConsensusSignatureScheme` can build with `default-features = false` to drop the alloy dependency entirely.

### Migration
Remove `.await` from every consensus call, drop `#[tokio::main]` / `#[tokio::test]` (no async runtime needed), and switch event subscribers from `recv().await` to a blocking `recv()` / `recv_timeout()`.

## Verification
- `cargo fmt --all --check` — clean
- `cargo clippy --all-features --tests -- -D warnings` — clean
- `cargo clippy --no-default-features` — clean (no alloy crates compiled)
- `cargo test --all-features` — 93 tests + 2 doctests pass
- Builds with and without default features
